### PR TITLE
Remove non-SDM exports from index

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,38 +16,16 @@
  */
 
 export {
-    ActionResult,
-    successOn,
-} from "./lib/action/ActionResult";
-export {
-    AtomistBuild,
-    AtomistLinkImage,
-    AtomistWebhookType,
-    postAtomistWebhook,
     webhookBaseUrl,
 } from "./lib/atomistWebhook";
-export {
-    AutomationClient,
-    automationClient,
-} from "./lib/automationClient";
 export {
     AnyOptions,
     BannerSection,
     Configuration,
     ConfigurationPostProcessor,
     configurationValue,
-    defaultConfiguration,
-    getUserConfig,
-    invokePostProcessors,
-    resolveWorkspaceIds,
-    UserConfig,
-    userConfigPath,
-    writeUserConfig,
 } from "./lib/configuration";
 export {
-    CommandHandler,
-    ConfigurableCommandHandler,
-    EventHandler,
     MappedParameter,
     MappedParameters,
     Parameter,
@@ -59,19 +37,14 @@ export {
 } from "./lib/decorators";
 export {
     automationClientInstance,
-    eventStore,
-    setEventStore,
 } from "./lib/globals";
-export { ApolloGraphClient } from "./lib/graph/ApolloGraphClient";
 import * as GraphQL from "./lib/graph/graphQL";
 export { GraphQL };
 export {
     HandleCommand,
-    SelfDescribingHandleCommand,
 } from "./lib/HandleCommand";
 export {
     EventFired,
-    HandleEvent,
 } from "./lib/HandleEvent";
 export {
     AutomationContextAware,
@@ -85,51 +58,14 @@ export {
     FailurePromise,
     HandlerError,
     HandlerResult,
-    RedirectResult,
     reduceResults,
     success,
     Success,
     SuccessPromise,
 } from "./lib/HandlerResult";
 export {
-    obtainGitInfo,
-} from "./lib/internal/env/gitInfo";
-export {
     BaseParameter,
-    declareMappedParameter,
-    declareParameter,
-    declareSecret,
 } from "./lib/internal/metadata/decoratorSupport";
-export {
-    Arg,
-    CommandInvocation,
-    Secret as PayloadSecret,
-} from "./lib/internal/invoker/Payload";
-export {
-    isCommandHandlerMetadata,
-} from "./lib/internal/metadata/metadata";
-export {
-    metadataFromInstance,
-} from "./lib/internal/metadata/metadataReading";
-export {
-    replacer,
-} from "./lib/internal/transport/AbstractRequestProcessor";
-export {
-    CommandIncoming,
-    EventIncoming,
-    RequestProcessor,
-} from "./lib/internal/transport/RequestProcessor";
-export {
-    RegistrationConfirmation,
-} from "./lib/internal/transport/websocket/WebSocketRequestProcessor";
-export {
-    AutomationContext,
-} from "./lib/internal/util/cls";
-import * as nsp from "./lib/internal/util/cls";
-export { nsp };
-export {
-    info,
-} from "./lib/internal/util/info";
 export {
     registerShutdownHook,
 } from "./lib/internal/util/shutdown";
@@ -138,28 +74,11 @@ export {
     toStringArray,
 } from "./lib/internal/util/string";
 export {
-    EventHandlerMetadata,
-    CommandHandlerMetadata,
-    MappedParameterDeclaration,
-    Parameter as MetadataParameter,
-} from "./lib/metadata/automationMetadata";
-export {
-    commandHandlerFrom,
     OnCommand,
 } from "./lib/onCommand";
 export {
-    eventHandlerFrom,
     OnEvent,
 } from "./lib/onEvent";
-export {
-    CommandDetails,
-} from "./lib/operations/CommandDetails";
-export {
-    AbstractRemoteRepoRef,
-} from "./lib/operations/common/AbstractRemoteRepoRef";
-export {
-    BitBucketRepoRef,
-} from "./lib/operations/common/BitBucketRepoRef";
 export {
     BitBucketServerRepoRef,
 } from "./lib/operations/common/BitBucketServerRepoRef";
@@ -167,98 +86,34 @@ export {
     gitHubRepoLoader,
 } from "./lib/operations/common/gitHubRepoLoader";
 export {
-    GitHubDotComBase,
     GitHubRepoRef,
-    isGitHubRepoRef,
 } from "./lib/operations/common/GitHubRepoRef";
-export {
-    EditorOrReviewerParameters,
-} from "./lib/operations/common/params/BaseEditorOrReviewerParameters";
-export {
-    FallbackParams,
-} from "./lib/operations/common/params/FallbackParams";
-export {
-    GitHubTargetsParams,
-} from "./lib/operations/common/params/GitHubTargetsParams";
 export {
     RemoteLocator,
 } from "./lib/operations/common/params/RemoteLocator";
-export {
-    TargetsParams,
-} from "./lib/operations/common/params/TargetsParams";
 import * as validationPatterns from "./lib/operations/common/params/validationPatterns";
 export { validationPatterns };
 export {
-    ProjectAction,
-} from "./lib/operations/common/projectAction";
-export {
-    isTokenCredentials,
     ProjectOperationCredentials,
     TokenCredentials,
 } from "./lib/operations/common/ProjectOperationCredentials";
 export {
-    andFilter,
-    RepoFilter,
-} from "./lib/operations/common/repoFilter";
-export {
-    RepoFinder,
-} from "./lib/operations/common/repoFinder";
-export {
-    isRemoteRepoRef,
     RemoteRepoRef,
     RepoId,
     RepoRef,
     SimpleRepoId,
 } from "./lib/operations/common/RepoId";
 export {
-    RepoLoader,
-} from "./lib/operations/common/repoLoader";
-export {
-    doWithAllRepos,
-} from "./lib/operations/common/repoUtils";
-export {
     SourceLocation,
 } from "./lib/operations/common/SourceLocation";
-export {
-    editAll,
-} from "./lib/operations/edit/editAll";
 export {
     EditMode,
 } from "./lib/operations/edit/editModes";
 import * as editModes from "./lib/operations/edit/editModes";
 export { editModes };
 export {
-    AnyProjectEditor,
-    EditResult,
-    failedEdit,
-    ProjectEditor,
     SimpleProjectEditor,
-    successfulEdit,
-    toEditor,
 } from "./lib/operations/edit/projectEditor";
-export {
-    chainEditors,
-    combineEditResults,
-} from "./lib/operations/edit/projectEditorOps";
-export {
-    BaseSeedDrivenGeneratorParameters,
-} from "./lib/operations/generate/BaseSeedDrivenGeneratorParameters";
-export {
-    generate,
-    ProjectPersister,
-} from "./lib/operations/generate/generatorUtils";
-export {
-    GitHubProjectPersister,
-} from "./lib/operations/generate/gitHubProjectPersister";
-export {
-    GitHubRepoCreationParameters,
-} from "./lib/operations/generate/GitHubRepoCreationParameters";
-export {
-    NewRepoCreationParameters,
-} from "./lib/operations/generate/NewRepoCreationParameters";
-export {
-    RemoteGitProjectPersister,
-} from "./lib/operations/generate/remoteGitProjectPersister";
 export {
     RepoCreationParameters,
 } from "./lib/operations/generate/RepoCreationParameters";
@@ -269,32 +124,25 @@ export {
     addAtomistWebhook,
 } from "./lib/operations/generate/support/addAtomistWebhook";
 export {
-    DefaultReviewComment,
     ProjectReview,
     ReviewComment,
     ReviewResult,
     Severity,
 } from "./lib/operations/review/ReviewResult";
 export {
-    DefaultTaggerTags,
     Tagger,
-    TagRouter,
     TaggerTags,
     unifiedTagger,
 } from "./lib/operations/tagger/Tagger";
 export {
-    File,
+    File as ProjectFile,
 } from "./lib/project/File";
 export {
-    AllFiles,
     DefaultExcludes,
 } from "./lib/project/fileGlobs";
 export {
-    Fingerprint,
+    Fingerprint as FingerprintData,
 } from "./lib/project/fingerprint/Fingerprint";
-export {
-    Configurable,
-} from "./lib/project/git/Configurable";
 export {
     GitCommandGitProject,
 } from "./lib/project/git/GitCommandGitProject";
@@ -308,40 +156,27 @@ export {
 export {
     isLocalProject,
     LocalProject,
-    ReleaseFunction,
 } from "./lib/project/local/LocalProject";
 export {
     NodeFsLocalProject,
 } from "./lib/project/local/NodeFsLocalProject";
 export {
-    InMemoryFile,
+    InMemoryFile as InMemoryProjectFile,
 } from "./lib/project/mem/InMemoryFile";
 export {
     InMemoryProject,
 } from "./lib/project/mem/InMemoryProject";
 export {
-    FileStream,
-    isProject,
     Project,
     ProjectAsync,
 } from "./lib/project/Project";
 export {
-    AbstractProject,
-} from "./lib/project/support/AbstractProject";
-export {
     doWithJson,
 } from "./lib/project/util/jsonUtils";
-export {
-    doWithAtMostOneMatch,
-    doWithMatches,
-} from "./lib/project/util/parseUtils";
 import * as parseUtils from "./lib/project/util/parseUtils";
 export { parseUtils };
 import * as projectUtils from "./lib/project/util/projectUtils";
 export { projectUtils };
-export {
-    isGitHubTeamMember,
-} from "./lib/secured";
 import * as secured from "./lib/secured";
 export { secured };
 export {
@@ -362,10 +197,6 @@ export * from "./lib/spi/http/axiosHttpClient";
 export * from "./lib/spi/http/curlHttpClient";
 export * from "./lib/spi/http/httpClient";
 export * from "./lib/spi/message/MessageClient";
-export {
-    DefaultSlackMessageClient,
-    MessageClientSupport,
-} from "./lib/spi/message/MessageClientSupport";
 import * as astUtils from "./lib/tree/ast/astUtils";
 export { astUtils };
 export {
@@ -381,21 +212,13 @@ export {
 export {
     TypeScriptES6FileParser,
 } from "./lib/tree/ast/typescript/TypeScriptFileParser";
-export {
-    Maker,
-    toFactory,
-} from "./lib/util/constructionUtils";
 export * from "./lib/util/exec";
 export {
     deepLink,
-    fileContent,
     Issue,
     raiseIssue,
 } from "./lib/util/gitHub";
 export * from "./lib/util/logger";
-export {
-    scanFreePort,
-} from "./lib/util/port";
 export {
     doWithRetry,
 } from "./lib/util/retry";


### PR DESCRIPTION
Remove exports from the index that are only used by our internal
libraries, leaving the index as the definition of the
automation-client public interface.

Closes #391