### PR TITLE
Exclude ingesters from gql-gen

### DIFF
--- a/bin/gql-gen.ts
+++ b/bin/gql-gen.ts
@@ -62,7 +62,7 @@ async function main(): Promise<void> {
             stdio: "inherit",
         };
 
-        const graphQlGlob = `${lib}/**/*.graphql`;
+        const graphQlGlob = `${lib}/graphql/!(ingester)/*.graphql`;
 
         const graphqlFiles = await util.promisify(glob)(graphQlGlob);
         if (graphqlFiles && graphqlFiles.length > 0) {


### PR DESCRIPTION
Do not include ingester specifications from GraphQL type generation.
This change also fixes the location of the `graphql` subdirectory to
directly under the `lib` or `src` directory.  This is a change, but
likely not breaking as the location of a project-specific schema.json
was already limited to `{lib,src}/graphql`.