### PR TITLE
Provide low-level child_process promise functions

### DIFF
--- a/lib/project/File.ts
+++ b/lib/project/File.ts
@@ -22,8 +22,8 @@ export interface FileCore {
 }
 
 /**
- * @deprecated
  * Convenient way to defer File operations with fluent API
+ * @deprecated just remove it
  */
 export interface FileScripting extends ScriptedFlushable<File> {
 
@@ -51,6 +51,7 @@ export interface FileAsync extends FileCore {
 
 }
 
+/* tslint:disable-next-line:deprecation */
 export interface FileNonBlocking extends FileScripting, FileAsync {
 
 }
@@ -76,6 +77,7 @@ export interface FileSync extends FileCore {
  * Abstraction for a File. Similar to Project abstraction,
  * broken into three distinct styles of usage.
  */
+/* tslint:disable-next-line:deprecation */
 export interface File extends FileScripting, FileSync, FileAsync {
 
     /**

--- a/lib/util/child_process.ts
+++ b/lib/util/child_process.ts
@@ -1,0 +1,281 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {
+    ChildProcess,
+    SpawnOptions,
+    SpawnSyncOptions,
+    SpawnSyncReturns,
+} from "child_process";
+import * as spawn from "cross-spawn";
+import * as process from "process";
+import stripAnsi = require("strip-ansi");
+import * as treeKill from "tree-kill";
+import { logger } from "./logger";
+
+export { spawn };
+
+/**
+ * Convert child process into an informative string.
+ *
+ * @param cmd Command being run.
+ * @param args Arguments to command.
+ * @param opts Standard child_process.SpawnOptions.
+ */
+export function childProcessString(cmd: string, args: string[] = [], opts: SpawnOptions = {}): string {
+    return (opts.cwd ? opts.cwd : process.cwd()) + " ==> " + cmd +
+        (args.length > 0 ? " '" + args.join("' '") + "'" : "");
+}
+
+/**
+ * Cross-platform kill a process and all its children using tree-kill.
+ * On win32, signal is ignored since win32 does not support different
+ * signals.
+ *
+ * @param cp child process to kill
+ * @param signal optional signal name or number, Node.js default is used if not provided
+ */
+export function crossKill(cp: ChildProcess, signal?: string | number): void {
+    const sig = (signal) ? `signal ${signal}` : "default signal";
+    logger.debug(`Calling tree-kill on child process ${cp.pid} with ${sig}`);
+    treeKill(cp.pid);
+}
+
+/**
+ * Interface for a writable log that provides a function to write to
+ * the log.
+ */
+export interface WritableLog {
+    /**
+     * The content already written to the log.  This is optional as
+     * some implementations may choose to not expose their log as a
+     * string as it could be too long.
+     */
+    log?: string;
+    /**
+     * Set to true if ANSI escape characters should be stripped from
+     * the data before writing to log.
+     */
+    stripAnsi?: boolean;
+    /** Function that appends to the log. */
+    write(what: string): void;
+}
+
+/**
+ * Add logging to standard SpawnSyncoptions.
+ */
+export interface SpawnPromiseOptions extends SpawnSyncOptions {
+    /** Optional logger to write stdout and stderr to. */
+    log?: WritableLog;
+    /**
+     * Set to true if you want the command line sent to the
+     * Writablelog provided to spawnPromise.  Set to false if the
+     * command or its arguments contain sensitive information.
+     */
+    logCommand?: boolean;
+}
+
+/**
+ * Safely clear a timer that may be undefined.
+ *
+ * @param timer A timer that may not be set.
+ */
+function clearTimer(timer: NodeJS.Timer | undefined): undefined {
+    if (timer) {
+        clearTimeout(timer);
+    }
+    return undefined;
+}
+
+export interface SpawnPromiseReturns extends SpawnSyncReturns<string> {
+    /** Stringified command. */
+    cmdString: string;
+}
+
+/**
+ * Call cross-spawn and return a Promise of its result.  The result
+ * has the same shape as the object returned by
+ * `child_process.spawnSync()`, which means errors are not thrown but
+ * returned in the `error` property of the returned object.  If your
+ * command will produce lots of output, provide a log to write it to.
+ *
+ * @param cmd Command to run.  If it is just an executable name, paths
+ *            with be searched, batch and command files will be checked,
+ *            etc.  See cross-spawn documentation for details.
+ * @param args Arguments to command.
+ * @param opts Standard child_process.SpawnOptions.
+ * @return a Promise that resolves to the ChildProcess that was executed.
+ */
+export async function spawnPromise(cmd: string, args: string[] = [], opts: SpawnPromiseOptions = {}): Promise<SpawnPromiseReturns> {
+    const cmdString = childProcessString(cmd, args, opts);
+    logger.debug(`Running: ${cmdString}`);
+    let logEncoding = "utf8";
+    if (!opts.encoding) {
+        if (opts.log) {
+            opts.encoding = "buffer";
+        } else {
+            opts.encoding = "utf8";
+        }
+    } else if (opts.log && opts.encoding !== "buffer") {
+        logEncoding = opts.encoding;
+        opts.encoding = "buffer";
+    }
+    const childProcess = spawn(cmd, args, opts);
+    logger.debug(`Spawned PID ${childProcess.pid}: ${cmdString}`);
+    if (opts.log && opts.logCommand) {
+        opts.log.write(`/--\n${cmdString} (PID ${childProcess.pid})\n\\--\n`);
+    }
+    let timer: NodeJS.Timer;
+    if (opts.timeout) {
+        timer = setTimeout(() => {
+            logger.warn(`Child process timeout expired, killing command: ${cmdString}`);
+            crossKill(childProcess, opts.killSignal);
+        }, opts.timeout);
+    }
+    return new Promise<SpawnPromiseReturns>((resolve, reject) => {
+        let stderr: string = "";
+        let stdout: string = "";
+        if (opts.log) {
+            function logData(data: Buffer): void {
+                const dataString = data.toString(logEncoding);
+                const formatted = (opts.log.stripAnsi) ? stripAnsi(dataString) : dataString;
+                opts.log.write(formatted);
+            }
+            childProcess.stderr.on("data", logData);
+            childProcess.stdout.on("data", logData);
+            stderr = stdout = "See log";
+        } else {
+            childProcess.stderr.on("data", (data: string) => stderr += data);
+            childProcess.stdout.on("data", (data: string) => stdout += data);
+        }
+        childProcess.on("exit", (code, signal) => {
+            timer = clearTimer(timer);
+            logger.debug(`Child process exit with code ${code} and signal ${signal}: ${cmdString}`);
+        });
+        childProcess.on("close", (code, signal) => {
+            timer = clearTimer(timer);
+            logger.debug(`Child process close with code ${code} and signal ${signal}: ${cmdString}`);
+            resolve({
+                cmdString,
+                pid: childProcess.pid,
+                output: [null, stdout, stderr],
+                stdout,
+                stderr,
+                status: code,
+                signal,
+                error: null,
+            });
+        });
+        childProcess.on("error", err => {
+            timer = clearTimer(timer);
+            err.message = `Failed to run command: ${cmdString}: ${err.message}`;
+            logger.error(err.message);
+            resolve({
+                cmdString,
+                pid: childProcess.pid,
+                output: [null, stdout, stderr],
+                stdout,
+                stderr,
+                status: null,
+                signal: null,
+                error: err,
+            });
+        });
+    });
+}
+
+/**
+ * Standard output and standard error from executing a child process.
+ * No code or signal is provided because if you receive this value,
+ * the child process completed successfully, i.e., exited normally
+ * with a status of 0.
+ */
+export interface ExecPromiseResult {
+    /** Child process standard output. */
+    stdout: string;
+    /** Child process standard error. */
+    stderr: string;
+}
+
+/**
+ * Error thrown when a command cannot be executed, the command is
+ * killed by a signal, or returns a non-zero exit status.
+ */
+export class ExecPromiseError extends Error implements ExecPromiseResult {
+    /** Create an ExecError from a SpawnSyncReturns<string> */
+    public static fromSpawnReturns(r: SpawnSyncReturns<string>): ExecPromiseError {
+        return new ExecPromiseError(r.error.message, r.pid, r.output, r.stdout, r.stderr, r.status, r.signal);
+    }
+
+    constructor(
+        /** Message describing reason for failure. */
+        public message: string,
+        /** Command PID. */
+        public pid: number,
+        /** stdio */
+        public output: string[],
+        /** Child process standard output. */
+        public stdout: string,
+        /** Child process standard error. */
+        public stderr: string,
+        /** Child process exit status. */
+        public status: number,
+        /** Signal that killed the process, if any. */
+        public signal: string,
+    ) {
+        super(message);
+        Object.setPrototypeOf(this, new.target.prototype);
+    }
+}
+
+/**
+ * Run a child process using cross-spawn, capturing and returning
+ * stdout and stderr, like exec, in a promise.  If an error occurs,
+ * the process is killed by a signal, or the process exits with a
+ * non-zero status, the Promise is rejected.  Any provided `stdio`
+ * option is ignored, being overwritten with `["pipe","pipe","pipe"]`.
+ * Like with child_process.exec, this is not a good choice if the
+ * command produces a large amount of data on stdout or stderr.
+ *
+ * @param cmd name of command, can be a shell script or MS Windows .bat or .cmd
+ * @param args command arguments
+ * @param opts standard child_process.SpawnOptions
+ * @return Promise resolving to exec-like callback arguments having stdout and stderr properties
+ */
+export async function execPromise(cmd: string, args: string[] = [], opts: SpawnSyncOptions = {}): Promise<ExecPromiseResult> {
+    opts.stdio = ["pipe", "pipe", "pipe"];
+    if (!opts.encoding) {
+        opts.encoding = "utf8";
+    }
+    const result = await spawnPromise(cmd, args, opts);
+    if (result.error) {
+        throw ExecPromiseError.fromSpawnReturns(result);
+    }
+    if (result.status) {
+        const msg = `Child process ${result.pid} exited with non-zero status ${result.status}: ${result.cmdString}\n${result.stderr}`;
+        logger.error(msg);
+        result.error = new Error(msg);
+        throw ExecPromiseError.fromSpawnReturns(result);
+    }
+    if (result.signal) {
+        const msg = `Child process ${result.pid} received signal ${result.signal}: ${result.cmdString}\n${result.stderr}`;
+        logger.error(msg);
+        result.error = new Error(msg);
+        throw ExecPromiseError.fromSpawnReturns(result);
+    }
+    return { stdout: result.stdout, stderr: result.stderr };
+}

--- a/lib/util/exec.ts
+++ b/lib/util/exec.ts
@@ -23,8 +23,11 @@ import * as process from "process";
 
 import { logger } from "./logger";
 
+/* tslint:disable:deprecation */
+
 /**
  * Standard output and standard error.
+ * @deprecated use ExecPromiseResult
  */
 export interface ExecResult {
     stdout: string;
@@ -34,6 +37,7 @@ export interface ExecResult {
 /**
  * Error thrown when a command cannot be executed, the command is
  * killed, or returns a non-zero exit status.
+ * @deprecated use ExecPromiseError
  */
 export class ExecError extends Error {
     constructor(
@@ -62,6 +66,7 @@ export class ExecError extends Error {
  * @param {string[]} args command arguments
  * @param {"child_process".SpawnOptions} opts standard spawn options
  * @return {Promise<ExecResult>} exec-like callback arguments having stdout and stderr properties
+ * @deprecated use execPromise
  */
 export async function safeExec(cmd: string, args: string[] = [], opts: SpawnOptions = {}): Promise<ExecResult> {
     const cmdString = (opts.cwd ? opts.cwd : process.cwd()) + " ==> " + cmd +
@@ -106,6 +111,7 @@ export async function safeExec(cmd: string, args: string[] = [], opts: SpawnOpti
  * @param cmd command to run
  * @param args command arguments
  * @return Promise of { stdout, stderr }
+ * @deprecated use execPromise
  */
 export async function execIn(baseDir: string, cmd: string, args: string[]): Promise<ExecResult> {
     return safeExec(cmd, args, { cwd: baseDir });

--- a/lib/util/retry.ts
+++ b/lib/util/retry.ts
@@ -29,7 +29,7 @@ export function doWithRetry<R>(what: () => Promise<R>,
         ...DefaultRetryOptions,
         ...opts,
     };
-    logger.log("silly",`${description} with retry options '%j'`, retryOptions);
+    logger.log("silly", `${description} with retry options '%j'`, retryOptions);
     return promiseRetry(retryOptions, retry => {
         return what()
             .catch(err => {

--- a/lib/util/spawn.ts
+++ b/lib/util/spawn.ts
@@ -22,26 +22,14 @@ import {
 import * as spawn from "cross-spawn";
 import * as os from "os";
 import * as path from "path";
-import * as strip_ansi from "strip-ansi";
-import * as treeKill from "tree-kill";
+import strip_ansi = require("strip-ansi");
+import {
+    crossKill,
+    WritableLog,
+} from "./child_process";
 import { logger } from "./logger";
 
-export { spawn };
-
-/**
- * Interface for a writable log that provides a function to write to the log.
- */
-export interface WritableLog {
-
-    /**
-     * Some implementations expose their log as a string.
-     * Others may not, as it could be too long etc.
-     */
-    log?: string;
-
-    /** Function that write to the log. */
-    write(what: string): void;
-}
+/* tslint:disable:deprecation */
 
 /**
  * Type that can react to the exit of a spawned child process, after
@@ -49,6 +37,7 @@ export interface WritableLog {
  * This is necessary only for commands that can return
  * a non-zero exit code on success.
  * @return whether this result should be considered an error.
+ * @deprecated use @atomist/sdm version
  */
 export type ErrorFinder = (code: number, signal: string, log: WritableLog) => boolean;
 
@@ -56,12 +45,13 @@ export type ErrorFinder = (code: number, signal: string, log: WritableLog) => bo
  * Default ErrorFinder that regards return code 0 as success
  * @param {number} code
  * @return {boolean}
- * @constructor
+ * @deprecated use @atomist/sdm version
  */
 export const SuccessIsReturn0ErrorFinder: ErrorFinder = code => code !== 0;
 
 /**
  * Result returned by spawnAndWatch after running a child process.
+ * @deprecated use @atomist/sdm version
  */
 export interface ChildProcessResult {
     /** Will be true if the ErrorFinder returns true. */
@@ -76,6 +66,7 @@ export interface ChildProcessResult {
 
 /**
  * spawnAndWatch specific options.
+ * @deprecated use @atomist/sdm version
  */
 export interface SpawnWatchOptions {
     /**
@@ -113,6 +104,7 @@ export interface SpawnWatchOptions {
  * @param log log to write output to
  * @param {Partial<SpawnWatchOptions>} spOpts
  * @return {Promise<ChildProcessResult>}
+ * @deprecated use @atomist/sdm version
  */
 export async function spawnAndWatch(spawnCommand: SpawnCommand,
                                     options: SpawnOptions,
@@ -136,6 +128,7 @@ export async function spawnAndWatch(spawnCommand: SpawnCommand,
  * @param log to write stdout and stderr to
  * @param opts: Options for error parsing, ANSI code stripping etc.
  * @return {Promise<ChildProcessResult>}
+ * @deprecated use @atomist/sdm version
  */
 async function watchSpawned(childProcess: ChildProcess,
                             log: WritableLog,
@@ -191,6 +184,7 @@ async function watchSpawned(childProcess: ChildProcess,
 
 /**
  * The first two arguments to Node spawn
+ * @deprecated use @atomist/sdm version
  */
 export interface SpawnCommand {
 
@@ -203,6 +197,7 @@ export interface SpawnCommand {
  * toString for a SpawnCommand. Used for logging.
  * @param {SpawnCommand} sc
  * @return {string}
+ * @deprecated use @atomist/sdm version
  */
 export function stringifySpawnCommand(sc: SpawnCommand): string {
     return `${sc.command}${(!!sc.args) ? " '" + sc.args.join("' '") + "'" : ""}`;
@@ -217,6 +212,7 @@ export function stringifySpawnCommand(sc: SpawnCommand): string {
  * @param {string} sentence command and argument string
  * @param options
  * @return {SpawnCommand}
+ * @deprecated use @atomist/sdm version
  */
 export function asSpawnCommand(sentence: string, options: SpawnOptions = {}): SpawnCommand {
     const split = sentence.split(" ");
@@ -240,6 +236,7 @@ export function asSpawnCommand(sentence: string, options: SpawnOptions = {}): Sp
  * @param wait the number of milliseconds to wait before sending SIGKILL and
  *             then erroring, default is 30000 ms
  * @return {Promise<any>}
+ * @deprecated use @atomist/sdm version
  */
 export async function poisonAndWait(childProcess: ChildProcess, wait: number = 30000): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -265,26 +262,8 @@ export async function poisonAndWait(childProcess: ChildProcess, wait: number = 3
 }
 
 /**
- * Cross-platform kill.  On win32, tree-kill is used and signal is
- * ignored since win32 does not support different signals.  On other
- * platforms, ChildProcess.kill(signal) is used.
- *
- * @param cp child process to kill
- * @param signal optional signal, Node.js default is used if not provided
- */
-export function crossKill(cp: ChildProcess, signal?: string): void {
-    if (os.platform() === "win32") {
-        logger.debug(`Calling tree-kill on child process ${cp.pid}`);
-        treeKill(cp.pid);
-    } else {
-        const sig = (signal) ? `signal ${signal}` : "default signal";
-        logger.debug(`Sending ${sig} to child process ${cp.pid}`);
-        cp.kill(signal);
-    }
-}
-
-/**
  * Clear provided timers and resolve a promise.
+ * @deprecated use @atomist/sdm version
  */
 function clearAndResolve(pid: number, resolve: () => void, ...timers: NodeJS.Timer[]): (code: number, signal: string) => void {
     return (code: number, signal: string) => {
@@ -296,6 +275,7 @@ function clearAndResolve(pid: number, resolve: () => void, ...timers: NodeJS.Tim
 
 /**
  * Clear provided timers and reject a promise.
+ * @deprecated use @atomist/sdm version
  */
 function clearAndReject(pid: number, reject: (e: Error) => void, ...timers: NodeJS.Timer[]): (reason: Error) => void {
     return (reason: Error) => {
@@ -310,6 +290,7 @@ function clearAndReject(pid: number, reject: (e: Error) => void, ...timers: Node
  * defined before clearing them.
  *
  * @param timers the timers to clear.
+ * @deprecated use @atomist/sdm version
  */
 function clearTimers(timers: NodeJS.Timer[]): void {
     timers.filter(t => !!t).map(t => clearTimeout(t));

--- a/lib/util/statsd.ts
+++ b/lib/util/statsd.ts
@@ -267,7 +267,7 @@ export class StatsdAutomationEventListener extends AutomationEventListenerSuppor
     private initGc() {
         try {
             const gc = require("gc-stats");
-            gc().on('stats', stats => {
+            gc().on("stats", stats => {
                 const gcType = GcTypes[stats.gctype];
 
                 const tags = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -833,6 +833,11 @@
         "@types/node": "*"
       }
     },
+    "@types/strip-ansi": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npmjs.org/@types/strip-ansi/-/strip-ansi-3.0.0.tgz",
+      "integrity": "sha1-m2PUU6a1SqhJGCIHcRoIvo7qSK4="
+    },
     "@types/through": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.29.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/retry": "^0.10.2",
     "@types/semver": "^5.5.0",
     "@types/shelljs": "^0.8.0",
+    "@types/strip-ansi": "^3.0.0",
     "@types/utf8": "^2.1.6",
     "@types/uuid": "^3.4.3",
     "@types/ws": "^6.0.0",

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -4,7 +4,6 @@ import * as stringify from "json-stringify-safe";
 import * as _ from "lodash";
 import "mocha";
 import * as path from "path";
-import { fail } from "power-assert";
 import * as assert from "power-assert";
 import * as tmp from "tmp-promise";
 
@@ -710,7 +709,7 @@ describe("configuration", () => {
             assert.equal(c.custom.foo, "foo");
         });
 
-        it("should resolve simple placeholder and apply default value", async() => {
+        it("should resolve simple placeholder and apply default value", async () => {
             const c = defaultConfiguration();
             c.custom = {
                 foo: "${BAR:super foo}",
@@ -748,17 +747,17 @@ describe("configuration", () => {
             assert.equal(c.custom.foo, "Careful Man, there's a beverage here!");
         });
 
-        it("should fail if placeholder can't be resolved",async () => {
+        it("should fail if placeholder can't be resolved", async () => {
             const c = defaultConfiguration();
             c.custom = {
                 foo: "Careful ${DUDE }, there's a ${DRINK:beverage} here!",
             };
             delete process.env.DUDE;
             try {
-                await resolvePlaceholders(c)
-                fail();
+                await resolvePlaceholders(c);
+                assert.fail();
             } catch (err) {
-
+                // ignore
             }
         });
 

--- a/test/project/git/CachedGitClone.test.ts
+++ b/test/project/git/CachedGitClone.test.ts
@@ -17,7 +17,7 @@ import {
     DefaultCloneOptions,
 } from "../../../lib/spi/clone/DirectoryManager";
 import { TmpDirectoryManager } from "../../../lib/spi/clone/tmpDirectoryManager";
-import { safeExec } from "../../../lib/util/exec";
+import { execPromise } from "../../../lib/util/child_process";
 import {
     Creds,
     GitHubToken,
@@ -250,7 +250,7 @@ describe("CachedGitClone", () => {
         it("clones to depth of 1 when transient", async () => {
             const clone1 = await cloneTransiently();
             const baseDir = clone1.baseDir;
-            const result = await safeExec("git", ["rev-list", "HEAD"], { cwd: baseDir });
+            const result = await execPromise("git", ["rev-list", "HEAD"], { cwd: baseDir });
             assert(result.stdout.trim().split("\n").length === 1, result.stdout);
             await clone1.release();
         }).timeout(20000);
@@ -258,10 +258,10 @@ describe("CachedGitClone", () => {
         it("clones fully when requested", async () => {
             const clone1 = await cloneTransiently({ alwaysDeep: true });
             const baseDir = clone1.baseDir;
-            const result = await safeExec("git", ["rev-list", "HEAD"], { cwd: baseDir });
+            const result = await execPromise("git", ["rev-list", "HEAD"], { cwd: baseDir });
             // we can see all the commits
             assert(result.stdout.trim().split("\n").length > 1);
-            const branchResult = await safeExec("git", ["rev-list", "this-tag-exists"], { cwd: baseDir });
+            const branchResult = await execPromise("git", ["rev-list", "this-tag-exists"], { cwd: baseDir });
             // now we have access to branches
             assert(branchResult.stdout.trim().split("\n").length >= 1);
             await clone1.release();

--- a/test/project/git/GitProject.test.ts
+++ b/test/project/git/GitProject.test.ts
@@ -1,5 +1,3 @@
-import "mocha";
-
 import * as assert from "power-assert";
 import { ActionResult } from "../../../lib/action/ActionResult";
 import {
@@ -9,7 +7,7 @@ import {
 import { GitCommandGitProject } from "../../../lib/project/git/GitCommandGitProject";
 import { GitProject } from "../../../lib/project/git/GitProject";
 import { Project } from "../../../lib/project/Project";
-import { safeExec } from "../../../lib/util/exec";
+import { execPromise } from "../../../lib/util/child_process";
 import { GitHubToken } from "../../credentials";
 import { tempProject } from "../utils";
 
@@ -97,7 +95,7 @@ describe("GitProject", () => {
 
 ding dong ding
 `))
-            .then(() => safeExec("git", ["log", "-1", "--pretty=format:%B"], { cwd: gp.baseDir }))
+            .then(() => execPromise("git", ["log", "-1", "--pretty=format:%B"], { cwd: gp.baseDir }))
             .then(commandResult => {
                 assert.equal(commandResult.stdout, `Added a Thing
 

--- a/test/project/local/NodeFsLocalFile.test.ts
+++ b/test/project/local/NodeFsLocalFile.test.ts
@@ -59,8 +59,7 @@ describe("NodeFsLocalFile", () => {
             .then(() => {
                 assert(f.getContentSync() === "The slow brown");
                 done();
-            },
-        );
+            });
     });
 
     it("should test nonbinary file", done => {
@@ -83,7 +82,7 @@ describe("NodeFsLocalFile", () => {
             + "3gAAAABJRU5ErkJggg==";
         // Strip off the data: url prefix to get just the base64-encoded bytes
         const data = img.replace(/^data:image\/\w+;base64,/, "");
-        const buf = new Buffer(data, "base64");
+        const buf = Buffer.from(data, "base64");
         fs.writeFileSync(p.baseDir + "/img", buf);
         const f = p.findFileSync("img");
         f.isBinary().then(bin => {

--- a/test/spi/clone/TmpDirectoryManager.test.ts
+++ b/test/spi/clone/TmpDirectoryManager.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs-extra";
 import "mocha";
 import * as assert from "power-assert";
 import { TmpDirectoryManager } from "../../../lib/spi/clone/tmpDirectoryManager";
-import { safeExec } from "../../../lib/util/exec";
+import { execPromise } from "../../../lib/util/child_process";
 
 describe("the TmpDirectoryManager", () => {
 
@@ -14,7 +14,7 @@ describe("the TmpDirectoryManager", () => {
                 const suppliedDirectory = cdi.path;
                 return fs.stat(suppliedDirectory) // if this succeeds, it exists
                     .then(() =>
-                        safeExec("git", ["init"], { cwd: suppliedDirectory })) // make it a little difficult
+                        execPromise("git", ["init"], { cwd: suppliedDirectory })) // make it a little difficult
                     .then(() => cdi.release())
                     .then(() => fs.stat(suppliedDirectory))
                     .then(() => {

--- a/test/util/spawn.test.ts
+++ b/test/util/spawn.test.ts
@@ -15,13 +15,15 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import * as spawn from "cross-spawn";
 import * as os from "os";
 import * as assert from "power-assert";
 import {
     poisonAndWait,
-    spawn,
     spawnAndWatch,
 } from "../../lib/util/spawn";
+
+/* tslint:disable:deprecation */
 
 describe("spawn", () => {
 

--- a/tslint.json
+++ b/tslint.json
@@ -9,6 +9,7 @@
             true,
             "ban-single-arg-parens"
         ],
+        "deprecation": true,
         "interface-name": [
             true,
             "never-prefix"


### PR DESCRIPTION
Provide low-level child_process promise interfaces and functions.
Deprecate old spawn and exec versions.  Move this project to use new
functions and interfaces.

Toward atomist/sdm#575