### PR TITLE
Extract creation of HTTP and WS clients for registration to proper factories

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -42,6 +42,13 @@ export {
     automationClientInstance,
 } from "./lib/globals";
 import * as GraphQL from "./lib/graph/graphQL";
+import * as validationPatterns from "./lib/operations/common/params/validationPatterns";
+import * as editModes from "./lib/operations/edit/editModes";
+import * as parseUtils from "./lib/project/util/parseUtils";
+import * as projectUtils from "./lib/project/util/projectUtils";
+import * as secured from "./lib/secured";
+import * as astUtils from "./lib/tree/ast/astUtils";
+
 export { GraphQL };
 export {
     EventFired,
@@ -100,7 +107,6 @@ export {
 export {
     RemoteLocator,
 } from "./lib/operations/common/params/RemoteLocator";
-import * as validationPatterns from "./lib/operations/common/params/validationPatterns";
 export { validationPatterns };
 export {
     ProjectOperationCredentials,
@@ -127,7 +133,6 @@ export {
 export {
     EditMode,
 } from "./lib/operations/edit/editModes";
-import * as editModes from "./lib/operations/edit/editModes";
 export { editModes };
 export {
     SimpleProjectEditor,
@@ -197,11 +202,8 @@ export {
 export {
     doWithJson,
 } from "./lib/project/util/jsonUtils";
-import * as parseUtils from "./lib/project/util/parseUtils";
 export { parseUtils };
-import * as projectUtils from "./lib/project/util/projectUtils";
 export { projectUtils };
-import * as secured from "./lib/secured";
 export { secured };
 export {
     AutomationEventListener,
@@ -221,7 +223,6 @@ export * from "./lib/spi/http/axiosHttpClient";
 export * from "./lib/spi/http/curlHttpClient";
 export * from "./lib/spi/http/httpClient";
 export * from "./lib/spi/message/MessageClient";
-import * as astUtils from "./lib/tree/ast/astUtils";
 export { astUtils };
 export {
     MatchResult,
@@ -248,6 +249,7 @@ export {
 export * from "./lib/util/logger";
 export {
     doWithRetry,
+    RetryOptions,
 } from "./lib/util/retry";
 export * from "./lib/util/spawn";
 export {

--- a/lib/configuration.ts
+++ b/lib/configuration.ts
@@ -39,6 +39,10 @@ import { AutomationMetadataProcessor } from "./spi/env/MetadataProcessor";
 import { SecretResolver } from "./spi/env/SecretResolver";
 import { DefaultHttpClientFactory } from "./spi/http/axiosHttpClient";
 import { HttpClientFactory } from "./spi/http/httpClient";
+import {
+    DefaultWebSocketFactory,
+    WebSocketFactory,
+} from "./spi/http/wsClient";
 import { Maker } from "./util/constructionUtils";
 import { logger } from "./util/logger";
 import { loadHostPackageJson } from "./util/packageJson";
@@ -148,6 +152,9 @@ export interface AutomationOptions extends AnyOptions {
     /** websocket configuration */
     ws?: {
         enabled?: boolean;
+        client?: {
+            factory?: WebSocketFactory,
+        },
         termination?: {
             /**
              * if true, give in-flight transactions `gracePeriod`
@@ -940,6 +947,9 @@ export const LocalDefaultConfiguration: Configuration = {
     },
     ws: {
         enabled: true,
+        client: {
+            factory: DefaultWebSocketFactory,
+        },
         termination: {
             graceful: false,
             gracePeriod: 10000,

--- a/lib/internal/transport/websocket/WebSocketClient.ts
+++ b/lib/internal/transport/websocket/WebSocketClient.ts
@@ -220,7 +220,7 @@ function register(registrationCallback: () => any,
                 method: HttpMethod.Post,
                 headers: { Authorization: authorization },
                 options: {
-                    timeout: configuration.ws.timeout || 10000,
+                    timeout: configuration.ws.timeout,
                 },
                 retry: { retries: 0, log: false },
             })

--- a/lib/internal/util/string.ts
+++ b/lib/internal/util/string.ts
@@ -71,6 +71,10 @@ export function obfuscateJson(key: string, value: any) {
         return undefined;
     } else if (key === "postProcessors") {
         return undefined;
+    } else if (key === "goal" || key === "goals") {
+        return undefined;
+    } else if (key.startsWith("_")) {
+        return undefined;
     }
     return value;
 }

--- a/lib/onCommand.ts
+++ b/lib/onCommand.ts
@@ -75,9 +75,9 @@ class FunctionWrappingCommandHandler<P> implements SelfDescribingHandleCommand<P
                 public description: string,
                 private h: OnCommand<P>,
                 private parametersFactory: Maker<P>,
-        // tslint:disable-next-line:variable-name
+                // tslint:disable-next-line:variable-name
                 private _tags: string | string[] = [],
-        // tslint:disable-next-line:variable-name
+                // tslint:disable-next-line:variable-name
                 private _intent: string | string[] = [],
                 private autoSubmit: boolean = false) {
         const newParamInstance = this.freshParametersInstance();

--- a/lib/spi/http/axiosHttpClient.ts
+++ b/lib/spi/http/axiosHttpClient.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 import { configureProxy } from "../../internal/util/http";
 import { doWithRetry } from "../../util/retry";
 import {
@@ -23,13 +23,13 @@ export class AxiosHttpClient implements HttpClient {
         };
 
         const request = () => {
-            return axios.request(configureProxy({
+            return axios.request(this.configureOptions(configureProxy({
                     url,
                     headers: optionsToUse.headers,
                     method: optionsToUse.method.toString().toUpperCase(),
                     data: optionsToUse.body,
                     ...optionsToUse.options,
-                }))
+                })))
                 .then(result => {
                     return {
                         status: result.status,
@@ -40,6 +40,10 @@ export class AxiosHttpClient implements HttpClient {
         };
 
         return doWithRetry<HttpResponse<T>>(request, `Requesting '${url}'`, optionsToUse.retry);
+    }
+
+    protected configureOptions(options: AxiosRequestConfig): AxiosRequestConfig {
+        return options;
     }
 }
 

--- a/lib/spi/http/httpClient.ts
+++ b/lib/spi/http/httpClient.ts
@@ -1,6 +1,7 @@
-import { WrapOptions } from "retry";
-import { DefaultRetryOptions } from "../../util/retry";
-import { AxiosHttpClientFactory } from "./axiosHttpClient";
+import {
+    DefaultRetryOptions,
+    RetryOptions,
+} from "../../util/retry";
 
 /**
  * Available HTTP request methods to use with HttpClient.
@@ -28,7 +29,7 @@ export interface HttpClientOptions {
     body?: any;
 
     /** Optional retry options */
-    retry?: WrapOptions;
+    retry?: RetryOptions;
 
     /** Raw options to be passed to the underlying implementation; Please use with care */
     options?: any;

--- a/lib/spi/http/wsClient.ts
+++ b/lib/spi/http/wsClient.ts
@@ -1,0 +1,37 @@
+import * as HttpsProxyAgent from "https-proxy-agent";
+import * as WebSocket from "ws";
+import { RegistrationConfirmation } from "../../internal/transport/websocket/WebSocketRequestProcessor";
+import { logger } from "../../util/logger";
+
+/**
+ * Factory to create a WebSocket instance.
+ */
+export interface WebSocketFactory {
+
+    /**
+     * Create a WebSocket for the provided registration
+     * @param registration
+     */
+    create(registration: RegistrationConfirmation): WebSocket;
+}
+
+/**
+ * WS based WebSocketFactory implementation
+ */
+export class WSWebSocketFactory implements WebSocketFactory {
+
+    public create(registration: RegistrationConfirmation): WebSocket {
+        return new WebSocket(registration.url, this.configureOptions({}));
+    }
+
+    protected configureOptions(options: WebSocket.ClientOptions): WebSocket.ClientOptions {
+        if (process.env.HTTPS_PROXY || process.env.https_proxy) {
+            const proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+            logger.debug(`WebSocket connection using proxy '${proxy}'`);
+            options.agent = new HttpsProxyAgent(proxy);
+        }
+        return options;
+    }
+}
+
+export const DefaultWebSocketFactory = new WSWebSocketFactory();

--- a/lib/util/retry.ts
+++ b/lib/util/retry.ts
@@ -34,7 +34,9 @@ export function doWithRetry<R>(what: () => Promise<R>,
         ...DefaultRetryOptions as WrapOptions,
         ...opts,
     };
-    logger.log("silly", `${description} with retry options '%j'`, retryOptions);
+    if (opts.log) {
+        logger.log("silly", `${description} with retry options '%j'`, retryOptions);
+    }
     return promiseRetry(retryOptions, retry => {
         return what()
             .catch(err => {

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -30,6 +30,7 @@ import {
     UserConfig,
 } from "../lib/configuration";
 import { DefaultHttpClientFactory } from "../lib/spi/http/axiosHttpClient";
+import { DefaultWebSocketFactory } from "../lib/spi/http/wsClient";
 
 describe("configuration", () => {
 
@@ -82,6 +83,9 @@ describe("configuration", () => {
             },
             compress: false,
             timeout: 10000,
+            client: {
+                factory: DefaultWebSocketFactory,
+            },
         },
         cluster: {
             enabled: false,


### PR DESCRIPTION
With this change, HTTP and WS client can be configured correctly to work
in all sorts of network situations, like tunnelling proxies.