### PR TITLE
Add `GraphClientFactory`

### DIFF
--- a/lib/configuration.ts
+++ b/lib/configuration.ts
@@ -37,8 +37,14 @@ import {
 import { AutomationEventListener } from "./server/AutomationEventListener";
 import { AutomationMetadataProcessor } from "./spi/env/MetadataProcessor";
 import { SecretResolver } from "./spi/env/SecretResolver";
-import { DefaultHttpClientFactory } from "./spi/http/axiosHttpClient";
-import { HttpClientFactory } from "./spi/http/httpClient";
+import {
+    DefaultGraphClientFactory,
+    GraphClientFactory,
+} from "./spi/graph/GraphClientFactory";
+import {
+    DefaultHttpClientFactory,
+    HttpClientFactory,
+} from "./spi/http/httpClient";
 import {
     DefaultWebSocketFactory,
     WebSocketFactory,
@@ -168,6 +174,11 @@ export interface AutomationOptions extends AnyOptions {
         compress?: boolean;
         /** timeout in milliseconds */
         timeout?: number;
+    };
+    graphql?: {
+        client?: {
+            factory: GraphClientFactory,
+        },
     };
     /** Atomist API endpoints */
     endpoints?: {
@@ -967,6 +978,11 @@ export const LocalDefaultConfiguration: Configuration = {
         },
         compress: false,
         timeout: 10000,
+    },
+    graphql: {
+        client: {
+            factory: DefaultGraphClientFactory,
+        },
     },
     applicationEvents: {
         enabled: false,

--- a/lib/graph/ApolloGraphClient.ts
+++ b/lib/graph/ApolloGraphClient.ts
@@ -31,15 +31,18 @@ export class ApolloGraphClient implements GraphClient {
      * Create a new GraphClient
      * @param endpoint GraphQL endpoint
      * @param headers any special headers to use
+     * @param fetch configured GlobalFetch instance to use for this GraphClient
      */
-    constructor(public endpoint: string, headers: any = {}) {
+    constructor(public endpoint: string,
+                headers: any = {},
+                fetch: GlobalFetch["fetch"] = buildAxiosFetch(axios.create(configureProxy({})))) {
         const cache = new InMemoryCache({
             addTypename: false,
         });
 
         const httpLink = createHttpLink({
             uri: endpoint,
-            fetch: buildAxiosFetch(axios.create(configureProxy({}))),
+            fetch,
         });
 
         const middlewareLink = new ApolloLink((operation, forward) => {

--- a/lib/internal/transport/RequestProcessor.ts
+++ b/lib/internal/transport/RequestProcessor.ts
@@ -31,6 +31,15 @@ export function isEventIncoming(event: any): event is EventIncoming {
     return !!event.data;
 }
 
+export function workspaceId(event: CommandIncoming | EventIncoming): string | undefined {
+    if (isCommandIncoming(event)) {
+        return event.team.id;
+    } else if (isEventIncoming(event)) {
+        return event.extensions.team_id;
+    }
+    return undefined;
+}
+
 export interface EventIncoming {
 
     data: any;

--- a/lib/spi/graph/GraphClientFactory.ts
+++ b/lib/spi/graph/GraphClientFactory.ts
@@ -1,0 +1,25 @@
+import { Configuration } from "../../configuration";
+import { ApolloGraphClientFactory } from "../../graph/ApolloGraphClientFactory";
+import { GraphClient } from "./GraphClient";
+
+/**
+ * Factory to create GraphClient instances
+ */
+export interface GraphClientFactory {
+
+    /**
+     * Create a GraphClient for the provided workspaceId
+     * @param workspaceId
+     * @param configuration
+     * @param authCallback
+     */
+    create(workspaceId: string,
+           configuration: Configuration,
+           token: string): GraphClient;
+
+}
+
+/**
+ * Default GraphClientFactory to use
+ */
+export const DefaultGraphClientFactory = new ApolloGraphClientFactory();

--- a/lib/spi/http/axiosHttpClient.ts
+++ b/lib/spi/http/axiosHttpClient.ts
@@ -56,11 +56,3 @@ export class AxiosHttpClientFactory implements HttpClientFactory {
         return new AxiosHttpClient();
     }
 }
-
-/**
- * Default HttpClientFactory which gets registered in the automation-client if not a
- * different HttpClientFactory implementation is configured.
- * @see Configuration.http.client.factory
- * @type {HttpClientFactory}
- */
-export const DefaultHttpClientFactory = new AxiosHttpClientFactory();

--- a/lib/spi/http/httpClient.ts
+++ b/lib/spi/http/httpClient.ts
@@ -2,6 +2,7 @@ import {
     DefaultRetryOptions,
     RetryOptions,
 } from "../../util/retry";
+import { AxiosHttpClientFactory } from "./axiosHttpClient";
 
 /**
  * Available HTTP request methods to use with HttpClient.
@@ -87,3 +88,11 @@ export const DefaultHttpClientOptions: HttpClientOptions = {
     headers: {},
     retry: DefaultRetryOptions,
 };
+
+/**
+ * Default HttpClientFactory which gets registered in the automation-client if not a
+ * different HttpClientFactory implementation is configured.
+ * @see Configuration.http.client.factory
+ * @type {HttpClientFactory}
+ */
+export const DefaultHttpClientFactory = new AxiosHttpClientFactory();

--- a/test/command/HelloWorld.ts
+++ b/test/command/HelloWorld.ts
@@ -17,7 +17,9 @@ import {
 import {
     addressEvent,
     addressSlackChannels,
+    addressSlackChannelsFromContext,
     addressSlackUsers,
+    addressSlackUsersFromContext,
 } from "../../lib/spi/message/MessageClient";
 import { SecretBaseHandler } from "./SecretBaseHandler";
 
@@ -42,6 +44,8 @@ export class HelloWorld extends SecretBaseHandler implements HandleCommand {
                 name: this.name,
             },
         };
+
+        await ctx.messageClient.send({ text: "test"}, await addressSlackUsersFromContext(ctx, "cd"));
 
         await ctx.messageClient.send({ text: "test" }, addressSlackChannels(ctx.workspaceId, "handlers"));
         await ctx.messageClient.send({ text: "test" }, addressSlackUsers(ctx.workspaceId, "cd"), { id: null });

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -29,7 +29,8 @@ import {
     TestingDefaultConfiguration,
     UserConfig,
 } from "../lib/configuration";
-import { DefaultHttpClientFactory } from "../lib/spi/http/axiosHttpClient";
+import { DefaultGraphClientFactory } from "../lib/spi/graph/GraphClientFactory";
+import { DefaultHttpClientFactory } from "../lib/spi/http/httpClient";
 import { DefaultWebSocketFactory } from "../lib/spi/http/wsClient";
 
 describe("configuration", () => {
@@ -86,6 +87,11 @@ describe("configuration", () => {
             timeout: 10000,
             client: {
                 factory: DefaultWebSocketFactory,
+            },
+        },
+        graphql: {
+            client: {
+                factory: DefaultGraphClientFactory,
             },
         },
         cluster: {

--- a/test/internal/transport/AbstractRequestProcessor.test.ts
+++ b/test/internal/transport/AbstractRequestProcessor.test.ts
@@ -50,7 +50,7 @@ class ConcreteRequestProcessor extends AbstractRequestProcessor {
     }
 
     protected createGraphClient(event: EventIncoming | CommandIncoming, context: AutomationContextAware): GraphClient {
-        throw new Error("Method not implemented: createGraphClient.");
+        throw new Error("Method not implemented: create.");
     }
 
     protected createMessageClient(event: EventIncoming | CommandIncoming, context: AutomationContextAware): MessageClient {

--- a/test/internal/transport/websocket/DefaultWebSocketTransportEventHandler.test.ts
+++ b/test/internal/transport/websocket/DefaultWebSocketTransportEventHandler.test.ts
@@ -9,6 +9,7 @@ import { Automations } from "../../../../lib/internal/metadata/metadata";
 import { DefaultWebSocketRequestProcessor } from "../../../../lib/internal/transport/websocket/DefaultWebSocketRequestProcessor";
 import { CommandHandlerMetadata } from "../../../../lib/metadata/automationMetadata";
 import { AutomationServer } from "../../../../lib/server/AutomationServer";
+import { DefaultGraphClientFactory } from "../../../../lib/spi/graph/GraphClientFactory";
 
 describe("DefaultWebSocketRequestProcessor", () => {
 
@@ -47,14 +48,21 @@ describe("DefaultWebSocketRequestProcessor", () => {
                 return Promise.resolve([{ code: 0 }]);
             }
         }
+
         class MockWebSocket {
             public send(data: any, cb?: (err: Error) => void) {
                 assert(JSON.parse(data).status.code === 0);
             }
         }
+
         const automations = new MockAutomationServer();
         const listener = new DefaultWebSocketRequestProcessor(automations,
-            { token: "xxx", endpoints: {api: "http://foo.com", graphql: "http://bar.com" }, ws: {}});
+            {
+                token: "xxx",
+                endpoints: { api: "http://foo.com", graphql: "http://bar.com" },
+                ws: {},
+                graphql: { client: { factory: DefaultGraphClientFactory } },
+            });
         listener.onRegistration({ url: "http://bla.com", jwt: "123456789", name: "goo", version: "1.0.0" });
         listener.onConnect((new MockWebSocket() as any) as WebSocket);
         listener.processEvent({
@@ -118,14 +126,21 @@ function verifyCommandHandler(code: number, callback: (result) => void) {
             throw new Error("Method not implemented.");
         }
     }
+
     class MockWebSocket {
         public send(data: any, cb?: (err: Error) => void) {
             assert(JSON.parse(data).status.code === code);
         }
     }
+
     const automations = new MockAutomationServer();
     const listener = new DefaultWebSocketRequestProcessor(automations,
-        { token: "xxx", endpoints: {api: "http://foo.com", graphql: "http://bar.com" }, ws: {}});
+        {
+            token: "xxx",
+            endpoints: { api: "http://foo.com", graphql: "http://bar.com" },
+            ws: {},
+            graphql: { client: { factory: DefaultGraphClientFactory } },
+        });
     listener.onRegistration({ url: "http://bla.com", jwt: "123456789", name: "goo", version: "1.0.0" });
     listener.onConnect((new MockWebSocket() as any) as WebSocket);
     listener.processCommand({


### PR DESCRIPTION
This allows to modify the creation of `GraphClient` instances through a factory. 

The default implementation `ApolloGraphClientFactory` allows to plug in strategies to modify the internally used fetch instance.