### PR TITLE
Introduce Commit editMode and allow PR to specify base

### DIFF
--- a/lib/operations/common/GitlabRepoRef.ts
+++ b/lib/operations/common/GitlabRepoRef.ts
@@ -73,7 +73,7 @@ export class GitlabRepoRef extends AbstractRemoteRepoRef {
 
     public async createRemote(creds: ProjectOperationCredentials, description: string, visibility): Promise<ActionResult<this>> {
         const gitlabUrl = GitlabRepoRef.concatUrl(this.apiBase, `projects`);
-        const httpClient = automationClientInstance().configuration.http.client.factory.create();
+        const httpClient = automationClientInstance().configuration.http.client.factory.create(gitlabUrl);
         return httpClient.exchange(gitlabUrl, {
             method: HttpMethod.Post,
             body: {
@@ -98,8 +98,8 @@ export class GitlabRepoRef extends AbstractRemoteRepoRef {
     }
 
     public deleteRemote(creds: ProjectOperationCredentials): Promise<ActionResult<this>> {
-        const httpClient = automationClientInstance().configuration.http.client.factory.create();
         const gitlabUrl = GitlabRepoRef.concatUrl(this.apiBase, `project/${this.owner}%2f${this.repo}`);
+        const httpClient = automationClientInstance().configuration.http.client.factory.create(gitlabUrl);
         logger.debug(`Making request to '${url}' to delete repo`);
         return httpClient.exchange(gitlabUrl, {
             method: HttpMethod.Delete,
@@ -125,8 +125,8 @@ export class GitlabRepoRef extends AbstractRemoteRepoRef {
 
     public raisePullRequest(credentials: ProjectOperationCredentials,
                             title: string, body: string, head: string, base: string): Promise<ActionResult<this>> {
-        const httpClient = automationClientInstance().configuration.http.client.factory.create();
         const gitlabUrl = GitlabRepoRef.concatUrl(this.apiBase, `projects/${this.owner}%2f${this.repo}/merge_requests`);
+        const httpClient = automationClientInstance().configuration.http.client.factory.create(gitlabUrl);
         logger.debug(`Making request to '${url}' to raise PR`);
         return httpClient.exchange(gitlabUrl, {
             method: HttpMethod.Post,

--- a/lib/operations/edit/editModes.ts
+++ b/lib/operations/edit/editModes.ts
@@ -55,15 +55,19 @@ export enum AutoMergeMode {
 }
 
 /**
+ * Describe the auto merge behavior
+ */
+export interface AutoMerge {
+    mode: AutoMergeMode | string;
+    method?: AutoMergeMethod;
+}
+
+/**
  * Represents a commit to a project on a branch
  */
 export interface BranchCommit extends EditMode {
     branch: string;
-
-    autoMerge?: {
-        mode: AutoMergeMode | string,
-        method?: AutoMergeMethod,
-    };
+    autoMerge?: AutoMerge;
 }
 
 /**
@@ -82,14 +86,28 @@ export function isBranchCommit(em: EditMode): em is BranchCommit {
 }
 
 /**
+ * Captures basic information to create a commit
+ */
+export class Commit implements BranchCommit {
+
+    constructor(public branch: string,
+                public message: string,
+                public autoMerge?: AutoMerge) {}
+}
+
+/**
  * Captures extra steps that must go into raising a PR
  */
-export class PullRequest implements BranchCommit {
+export class PullRequest extends Commit {
 
     constructor(public branch: string,
                 public title: string,
                 public body: string = title,
-                public message: string = title) {
+                public message: string = title,
+                // Make default to master for backwards-compatible reasons
+                public targetBranch: string = "master",
+                public autoMerge?: AutoMerge) {
+        super(branch, message, autoMerge);
     }
 }
 

--- a/lib/operations/support/editorUtils.ts
+++ b/lib/operations/support/editorUtils.ts
@@ -153,7 +153,7 @@ ${ci.autoMerge.mode} ${ci.autoMerge.method ? ci.autoMerge.method : ""}`.trim();
 export function raisePr(gp: GitProject, pr: PullRequest): Promise<EditResult> {
     return createAndPushBranch(gp, pr)
         .then(x => {
-            return gp.raisePullRequest(pr.title, pr.body)
+            return gp.raisePullRequest(pr.title, pr.body, pr.targetBranch)
                 .then(r => successfulEdit(gp, true));
         });
 }

--- a/lib/project/git/GitProject.ts
+++ b/lib/project/git/GitProject.ts
@@ -90,8 +90,9 @@ export interface GitProject extends LocalProject, Configurable {
      * Raise a PR after a push to this branch
      * @param title
      * @param body
+     * @param targetBranch
      */
-    raisePullRequest(title: string, body: string): Promise<this>;
+    raisePullRequest(title: string, body: string, targetBranch?: string): Promise<this>;
 
     /**
      * Commit to local git


### PR DESCRIPTION
Adding the missing `Commit` edit mode instead of creating a `BranchCommit` manually. This is better for code completion.

Added support for target branch to `PullRequest`. Pass the `targetBranch` to the underlying PR creation functions in the repo refs.

Also fixed the calls to `HttpClientFactory.create` in the Gitlab support to pass the URL.