### PR TITLE
Export execPromise

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -239,6 +239,7 @@ export {
 } from "./lib/tree/ast/typescript/TypeScriptFileParser";
 export {
     WritableLog,
+    execPromise,
 } from "./lib/util/child_process";
 export * from "./lib/util/exec";
 export {


### PR DESCRIPTION
I observe that safeExec is deprecated in favor of this function, but it is not exported in the index