### PR TITLE
Performance optimization in AST parsing

### DIFF
--- a/lib/tree/ast/FileParser.ts
+++ b/lib/tree/ast/FileParser.ts
@@ -23,6 +23,16 @@ export interface FileParser<TN extends TreeNode = TreeNode> {
     toAst(f: File): Promise<TN>;
 
     /**
+     * If this method is supplied, it can help with optimization.
+     * If we can look at the path expression and determine a match is impossible
+     * in this file, we may be able to skip an expensive parsing operation.
+     * @param {File} f
+     * @param {PathExpression} pex
+     * @return {Promise<boolean>}
+     */
+    couldBeMatchesInThisFile?(pex: PathExpression, f: File): Promise<boolean>;
+
+    /**
      * Can this path expression possibly be valid using this parser?
      * For example, if the implementation is backed by the grammar for a programming
      * language, the set of symbols is known in advance, as is the legality of their

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -98,7 +98,8 @@ export async function findFileMatches(p: ProjectAsync,
     if (!parser) {
         throw new Error(`Cannot find parser for path expression [${pathExpression}]: Using ${parserOrRegistry}`);
     }
-    const files = await gatherFromFiles(p, globPatterns, file => parseFile(parser, parsed, functionRegistry, p, file));
+    const valuesToCheckFor = literalValues(parsed);
+    const files = await gatherFromFiles(p, globPatterns, file => parseFile(parser, parsed, functionRegistry, p, file, valuesToCheckFor));
     const all = await Promise.all(files);
     return all.filter(x => !!x);
 }
@@ -107,9 +108,9 @@ async function parseFile(parser: FileParser,
                          pex: PathExpression,
                          functionRegistry: FunctionRegistry,
                          p: ProjectAsync,
-                         file: File): Promise<FileHit> {
+                         file: File,
+                         valuesToCheckFor: string[]): Promise<FileHit> {
     // First, apply optimizations
-    const valuesToCheckFor = literalValues(pex);
     if (valuesToCheckFor.length > 0) {
         const content = await file.getContent();
         if (valuesToCheckFor.some(literal => !content.includes(literal))) {

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -12,16 +12,16 @@ import {
 import * as _ from "lodash";
 import { logger } from "../../util/logger";
 
-import { File } from "../../project/File";
-import { ProjectAsync } from "../../project/Project";
-import { gatherFromFiles, GlobOptions, } from "../../project/util/projectUtils";
-import { toSourceLocation } from "../../project/util/sourceLocationUtils";
-import { LocatedTreeNode } from "../LocatedTreeNode";
-import { FileHit, MatchResult, NodeReplacementOptions, } from "./FileHits";
-import { FileParser, isFileParser, } from "./FileParser";
-import { FileParserRegistry } from "./FileParserRegistry";
 import { Predicate } from "@atomist/tree-path/lib/path/pathExpression";
 import { AttributeEqualityPredicate, NestedPathExpressionPredicate } from "@atomist/tree-path/lib/path/predicates";
+import { File } from "../../project/File";
+import { ProjectAsync } from "../../project/Project";
+import { gatherFromFiles, GlobOptions } from "../../project/util/projectUtils";
+import { toSourceLocation } from "../../project/util/sourceLocationUtils";
+import { LocatedTreeNode } from "../LocatedTreeNode";
+import { FileHit, MatchResult, NodeReplacementOptions } from "./FileHits";
+import { FileParser, isFileParser } from "./FileParser";
+import { FileParserRegistry } from "./FileParserRegistry";
 
 /**
  * Integrate path expressions with project operations to find all matches

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -13,14 +13,27 @@ import * as _ from "lodash";
 import { logger } from "../../util/logger";
 
 import { Predicate } from "@atomist/tree-path/lib/path/pathExpression";
-import { AttributeEqualityPredicate, NestedPathExpressionPredicate } from "@atomist/tree-path/lib/path/predicates";
+import {
+    AttributeEqualityPredicate,
+    NestedPathExpressionPredicate,
+} from "@atomist/tree-path/lib/path/predicates";
 import { File } from "../../project/File";
 import { ProjectAsync } from "../../project/Project";
-import { gatherFromFiles, GlobOptions } from "../../project/util/projectUtils";
+import {
+    gatherFromFiles,
+    GlobOptions,
+} from "../../project/util/projectUtils";
 import { toSourceLocation } from "../../project/util/sourceLocationUtils";
 import { LocatedTreeNode } from "../LocatedTreeNode";
-import { FileHit, MatchResult, NodeReplacementOptions } from "./FileHits";
-import { FileParser, isFileParser } from "./FileParser";
+import {
+    FileHit,
+    MatchResult,
+    NodeReplacementOptions,
+} from "./FileHits";
+import {
+    FileParser,
+    isFileParser,
+} from "./FileParser";
 import { FileParserRegistry } from "./FileParserRegistry";
 
 /**

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -102,6 +102,10 @@ async function parseFile(parser: FileParser,
                          functionRegistry: FunctionRegistry,
                          p: ProjectAsync,
                          file: File): Promise<FileHit> {
+    if (!!parser.couldBeMatchesInThisFile && !await parser.couldBeMatchesInThisFile(pex, file)) {
+        // Skip parsing as we know there can never be matches
+        return undefined;
+    }
     return parser.toAst(file)
         .then(topLevelProduction => {
             logger.debug("Successfully parsed file '%s' to AST with root node named '%s'. Will execute '%s'",

--- a/test/tree/ast/astUtils.test.ts
+++ b/test/tree/ast/astUtils.test.ts
@@ -5,7 +5,8 @@ import { InMemoryFile } from "../../../lib/project/mem/InMemoryFile";
 import { InMemoryProject } from "../../../lib/project/mem/InMemoryProject";
 import {
     findMatches,
-    gatherFromMatches, literalValues,
+    gatherFromMatches,
+    literalValues,
     zapAllMatches,
 } from "../../../lib/tree/ast/astUtils";
 import { ZapTrailingWhitespace } from "../../../lib/tree/ast/FileHits";

--- a/test/tree/ast/astUtils.test.ts
+++ b/test/tree/ast/astUtils.test.ts
@@ -1,3 +1,4 @@
+import { toPathExpression } from "@atomist/tree-path";
 import "mocha";
 import * as assert from "power-assert";
 import { InMemoryFile } from "../../../lib/project/mem/InMemoryFile";
@@ -9,7 +10,6 @@ import {
 } from "../../../lib/tree/ast/astUtils";
 import { ZapTrailingWhitespace } from "../../../lib/tree/ast/FileHits";
 import { TypeScriptES6FileParser } from "../../../lib/tree/ast/typescript/TypeScriptFileParser";
-import { toPathExpression } from "@atomist/tree-path";
 
 describe("astUtils", () => {
 


### PR DESCRIPTION
Optimize, determining whether a file needs to be parsed based on literal value tests using string searches before invoking an actual `FileParser`.

When using expensive parsers such as ANTLR, this can increase performance by many times greatly reducing the number of files that need to be parsed.

Also add an optional method `FileParser` implementations can implement to provide further optimization.