### PR TITLE
Performance optimization for AST parsing

### DIFF
--- a/lib/project/util/projectUtils.ts
+++ b/lib/project/util/projectUtils.ts
@@ -1,8 +1,8 @@
-import { defer, ScriptedFlushable, } from "../../internal/common/Flushable";
+import { defer, ScriptedFlushable } from "../../internal/common/Flushable";
 import { isPromise } from "../../internal/util/async";
 import { toStringArray } from "../../internal/util/string";
 import { File } from "../File";
-import { FileStream, ProjectAsync, } from "../Project";
+import { FileStream, ProjectAsync } from "../Project";
 
 /**
  * Promise of an array of files. Usually sourced from Project.streamFiles

--- a/lib/project/util/projectUtils.ts
+++ b/lib/project/util/projectUtils.ts
@@ -1,8 +1,14 @@
-import { defer, ScriptedFlushable } from "../../internal/common/Flushable";
+import {
+    defer,
+    ScriptedFlushable,
+} from "../../internal/common/Flushable";
 import { isPromise } from "../../internal/util/async";
 import { toStringArray } from "../../internal/util/string";
 import { File } from "../File";
-import { FileStream, ProjectAsync } from "../Project";
+import {
+    FileStream,
+    ProjectAsync,
+} from "../Project";
 
 /**
  * Promise of an array of files. Usually sourced from Project.streamFiles

--- a/lib/project/util/projectUtils.ts
+++ b/lib/project/util/projectUtils.ts
@@ -1,8 +1,15 @@
-import { defer, ScriptedFlushable } from "../../internal/common/Flushable";
+import {
+    defer,
+    ScriptedFlushable,
+} from "../../internal/common/Flushable";
 import { isPromise } from "../../internal/util/async";
 import { toStringArray } from "../../internal/util/string";
 import { File } from "../File";
-import { FileStream, Project, ProjectAsync } from "../Project";
+import {
+    FileStream,
+    Project,
+    ProjectAsync,
+} from "../Project";
 
 /**
  * Promise of an array of files. Usually sourced from Project.streamFiles

--- a/lib/project/util/projectUtils.ts
+++ b/lib/project/util/projectUtils.ts
@@ -1,14 +1,8 @@
-import {
-    defer,
-    ScriptedFlushable,
-} from "../../internal/common/Flushable";
+import { defer, ScriptedFlushable, } from "../../internal/common/Flushable";
 import { isPromise } from "../../internal/util/async";
 import { toStringArray } from "../../internal/util/string";
 import { File } from "../File";
-import {
-    FileStream,
-    ProjectAsync,
-} from "../Project";
+import { FileStream, Project, ProjectAsync, } from "../Project";
 
 /**
  * Promise of an array of files. Usually sourced from Project.streamFiles
@@ -90,23 +84,19 @@ export function gatherFromFiles<T>(project: ProjectAsync,
 
 /**
  * Async generator to iterate over files.
- * @param {ProjectAsync} project to act on
+ * @param {Project} project to act on
  * @param {string} globPatterns glob pattern for files to match
- * @param {(f: File) => Promise<T>} gather function returning a promise (of the value you're gathering) from each file.
- * Undefined returns will be filtered out
+ * @param filter function to determine whether this file should be included.
+ * Include all files if this function isn't supplied.
  * @return {Promise<T[]>}
  */
-export async function* iterateFiles<T>(project: ProjectAsync,
-                                       globPatterns: GlobOptions,
-                                       gather: (f: File) => Promise<T> | undefined): AsyncIterable<T> {
+export async function* fileIterator(project: Project,
+                                    globPatterns: GlobOptions,
+                                    filter: (f: File) => Promise<boolean> = async () => true): AsyncIterable<File> {
     const files = await toPromise(project.streamFiles(...toStringArray(globPatterns)));
     for (const file of files) {
-        const prom = gather(file);
-        if (!!prom) {
-            const r = await prom;
-            if (!!r) {
-                yield r;
-            }
+        if (await filter(file)) {
+            yield file;
         }
     }
 }

--- a/lib/project/util/projectUtils.ts
+++ b/lib/project/util/projectUtils.ts
@@ -1,8 +1,8 @@
-import { defer, ScriptedFlushable, } from "../../internal/common/Flushable";
+import { defer, ScriptedFlushable } from "../../internal/common/Flushable";
 import { isPromise } from "../../internal/util/async";
 import { toStringArray } from "../../internal/util/string";
 import { File } from "../File";
-import { FileStream, Project, ProjectAsync, } from "../Project";
+import { FileStream, Project, ProjectAsync } from "../Project";
 
 /**
  * Promise of an array of files. Usually sourced from Project.streamFiles

--- a/lib/tree/ast/FileParser.ts
+++ b/lib/tree/ast/FileParser.ts
@@ -23,6 +23,16 @@ export interface FileParser<TN extends TreeNode = TreeNode> {
     toAst(f: File): Promise<TN>;
 
     /**
+     * If this method is supplied, it can help with optimization.
+     * If we can look at the path expression and determine a match is impossible
+     * in this file, we may be able to skip an expensive parsing operation.
+     * @param {File} f
+     * @param {PathExpression} pex
+     * @return {Promise<boolean>}
+     */
+    couldBeMatchesInThisFile?(pex: PathExpression, f: File): Promise<boolean>;
+
+    /**
      * Can this path expression possibly be valid using this parser?
      * For example, if the implementation is backed by the grammar for a programming
      * language, the set of symbols is known in advance, as is the legality of their

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -13,14 +13,14 @@ import * as _ from "lodash";
 import { logger } from "../../util/logger";
 
 import { Predicate } from "@atomist/tree-path/lib/path/pathExpression";
-import { AttributeEqualityPredicate, NestedPathExpressionPredicate, } from "@atomist/tree-path/lib/path/predicates";
+import { AttributeEqualityPredicate, NestedPathExpressionPredicate } from "@atomist/tree-path/lib/path/predicates";
 import { File } from "../../project/File";
 import { Project, ProjectAsync } from "../../project/Project";
-import { fileIterator, gatherFromFiles, GlobOptions, } from "../../project/util/projectUtils";
+import { fileIterator, gatherFromFiles, GlobOptions } from "../../project/util/projectUtils";
 import { toSourceLocation } from "../../project/util/sourceLocationUtils";
 import { LocatedTreeNode } from "../LocatedTreeNode";
-import { FileHit, MatchResult, NodeReplacementOptions, } from "./FileHits";
-import { FileParser, isFileParser, } from "./FileParser";
+import { FileHit, MatchResult, NodeReplacementOptions } from "./FileHits";
+import { FileParser, isFileParser } from "./FileParser";
 import { FileParserRegistry } from "./FileParserRegistry";
 
 /**

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -98,7 +98,8 @@ export async function findFileMatches(p: ProjectAsync,
     if (!parser) {
         throw new Error(`Cannot find parser for path expression [${pathExpression}]: Using ${parserOrRegistry}`);
     }
-    const files = await gatherFromFiles(p, globPatterns, file => parseFile(parser, parsed, functionRegistry, p, file));
+    const valuesToCheckFor = literalValues(parsed);
+    const files = await gatherFromFiles(p, globPatterns, file => parseFile(parser, parsed, functionRegistry, p, file, valuesToCheckFor));
     const all = await Promise.all(files);
     return all.filter(x => !!x);
 }
@@ -107,9 +108,9 @@ async function parseFile(parser: FileParser,
                          pex: PathExpression,
                          functionRegistry: FunctionRegistry,
                          p: ProjectAsync,
-                         file: File): Promise<FileHit> {
+                         file: File,
+                         valuesToCheckFor: string[]): Promise<FileHit> {
     // First, apply optimizations
-    const valuesToCheckFor = literalValues(pex);
     if (valuesToCheckFor.length > 0) {
         const content = await file.getContent();
         if (valuesToCheckFor.some(literal => !content.includes(literal))) {

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -12,16 +12,16 @@ import {
 import * as _ from "lodash";
 import { logger } from "../../util/logger";
 
-import { File } from "../../project/File";
-import { ProjectAsync } from "../../project/Project";
-import { gatherFromFiles, GlobOptions, } from "../../project/util/projectUtils";
-import { toSourceLocation } from "../../project/util/sourceLocationUtils";
-import { LocatedTreeNode } from "../LocatedTreeNode";
-import { FileHit, MatchResult, NodeReplacementOptions, } from "./FileHits";
-import { FileParser, isFileParser, } from "./FileParser";
-import { FileParserRegistry } from "./FileParserRegistry";
 import { Predicate } from "@atomist/tree-path/lib/path/pathExpression";
 import { AttributeEqualityPredicate, NestedPathExpressionPredicate } from "@atomist/tree-path/lib/path/predicates";
+import { File } from "../../project/File";
+import { ProjectAsync } from "../../project/Project";
+import { gatherFromFiles, GlobOptions } from "../../project/util/projectUtils";
+import { toSourceLocation } from "../../project/util/sourceLocationUtils";
+import { LocatedTreeNode } from "../LocatedTreeNode";
+import { FileHit, MatchResult, NodeReplacementOptions } from "./FileHits";
+import { FileParser, isFileParser } from "./FileParser";
+import { FileParserRegistry } from "./FileParserRegistry";
 
 /**
  * Integrate path expressions with project operations to find all matches

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -13,14 +13,31 @@ import * as _ from "lodash";
 import { logger } from "../../util/logger";
 
 import { Predicate } from "@atomist/tree-path/lib/path/pathExpression";
-import { AttributeEqualityPredicate, NestedPathExpressionPredicate } from "@atomist/tree-path/lib/path/predicates";
+import {
+    AttributeEqualityPredicate,
+    NestedPathExpressionPredicate,
+} from "@atomist/tree-path/lib/path/predicates";
 import { File } from "../../project/File";
-import { Project, ProjectAsync } from "../../project/Project";
-import { fileIterator, gatherFromFiles, GlobOptions } from "../../project/util/projectUtils";
+import {
+    Project,
+    ProjectAsync,
+} from "../../project/Project";
+import {
+    fileIterator,
+    gatherFromFiles,
+    GlobOptions,
+} from "../../project/util/projectUtils";
 import { toSourceLocation } from "../../project/util/sourceLocationUtils";
 import { LocatedTreeNode } from "../LocatedTreeNode";
-import { FileHit, MatchResult, NodeReplacementOptions } from "./FileHits";
-import { FileParser, isFileParser } from "./FileParser";
+import {
+    FileHit,
+    MatchResult,
+    NodeReplacementOptions,
+} from "./FileHits";
+import {
+    FileParser,
+    isFileParser,
+} from "./FileParser";
 import { FileParserRegistry } from "./FileParserRegistry";
 
 /**

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -13,14 +13,27 @@ import * as _ from "lodash";
 import { logger } from "../../util/logger";
 
 import { Predicate } from "@atomist/tree-path/lib/path/pathExpression";
-import { AttributeEqualityPredicate, NestedPathExpressionPredicate } from "@atomist/tree-path/lib/path/predicates";
+import {
+    AttributeEqualityPredicate,
+    NestedPathExpressionPredicate,
+} from "@atomist/tree-path/lib/path/predicates";
 import { File } from "../../project/File";
 import { ProjectAsync } from "../../project/Project";
-import { gatherFromFiles, GlobOptions } from "../../project/util/projectUtils";
+import {
+    gatherFromFiles,
+    GlobOptions,
+} from "../../project/util/projectUtils";
 import { toSourceLocation } from "../../project/util/sourceLocationUtils";
 import { LocatedTreeNode } from "../LocatedTreeNode";
-import { FileHit, MatchResult, NodeReplacementOptions } from "./FileHits";
-import { FileParser, isFileParser } from "./FileParser";
+import {
+    FileHit,
+    MatchResult,
+    NodeReplacementOptions,
+} from "./FileHits";
+import {
+    FileParser,
+    isFileParser,
+} from "./FileParser";
 import { FileParserRegistry } from "./FileParserRegistry";
 
 /**

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -21,7 +21,8 @@ import { File } from "../../project/File";
 import { ProjectAsync } from "../../project/Project";
 import {
     gatherFromFiles,
-    GlobOptions, iterateFiles,
+    GlobOptions,
+    iterateFiles,
 } from "../../project/util/projectUtils";
 import { toSourceLocation } from "../../project/util/sourceLocationUtils";
 import { LocatedTreeNode } from "../LocatedTreeNode";

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -102,6 +102,10 @@ async function parseFile(parser: FileParser,
                          functionRegistry: FunctionRegistry,
                          p: ProjectAsync,
                          file: File): Promise<FileHit> {
+    if (!!parser.couldBeMatchesInThisFile && !await parser.couldBeMatchesInThisFile(pex, file)) {
+        // Skip parsing as we know there can never be matches
+        return undefined;
+    }
     return parser.toAst(file)
         .then(topLevelProduction => {
             logger.debug("Successfully parsed file '%s' to AST with root node named '%s'. Will execute '%s'",

--- a/test/project/util/projectUtils.test.ts
+++ b/test/project/util/projectUtils.test.ts
@@ -8,8 +8,8 @@ import {
     deleteFiles,
     doWithFiles,
     fileExists,
-    gatherFromFiles,
     fileIterator,
+    gatherFromFiles,
 } from "../../../lib/project/util/projectUtils";
 import { tempProject } from "../utils";
 

--- a/test/project/util/projectUtils.test.ts
+++ b/test/project/util/projectUtils.test.ts
@@ -1,4 +1,3 @@
-
 import * as assert from "power-assert";
 
 import { defer } from "../../../lib/internal/common/Flushable";
@@ -9,7 +8,7 @@ import {
     deleteFiles,
     doWithFiles,
     fileExists,
-    gatherFromFiles,
+    gatherFromFiles, iterateFiles,
 } from "../../../lib/project/util/projectUtils";
 import { tempProject } from "../utils";
 
@@ -90,6 +89,20 @@ describe("projectUtils", () => {
                 assert(gathered[0] === "Thing");
             })
             .then(done, done);
+    });
+
+    it("gatherFromFiles generator", async () => {
+        const t = tempProject();
+        t.addFileSync("Thing", "1");
+        const it = iterateFiles<string>(t, AllFiles, async f => {
+            return f.path;
+        });
+        const gathered = [];
+        for await (const what of it) {
+            gathered.push(what);
+        }
+        assert.strictEqual(gathered.length,  1);
+        assert.strictEqual(gathered[0], "Thing");
     });
 
     it("withFiles: run", done => {

--- a/test/project/util/projectUtils.test.ts
+++ b/test/project/util/projectUtils.test.ts
@@ -9,7 +9,7 @@ import {
     doWithFiles,
     fileExists,
     gatherFromFiles,
-    iterateFiles,
+    fileIterator,
 } from "../../../lib/project/util/projectUtils";
 import { tempProject } from "../utils";
 
@@ -92,18 +92,27 @@ describe("projectUtils", () => {
             .then(done, done);
     });
 
-    it("gatherFromFiles generator", async () => {
+    it("fileIterator: take all", async () => {
         const t = tempProject();
         t.addFileSync("Thing", "1");
-        const it = iterateFiles<string>(t, AllFiles, async f => {
-            return f.path;
-        });
+        const it = fileIterator(t, AllFiles, async () => true);
         const gathered = [];
         for await (const what of it) {
             gathered.push(what);
         }
         assert.strictEqual(gathered.length,  1);
-        assert.strictEqual(gathered[0], "Thing");
+        assert.strictEqual(gathered[0].path, "Thing");
+    });
+
+    it("fileIterator: take none", async () => {
+        const t = tempProject();
+        t.addFileSync("Thing", "1");
+        const it = fileIterator(t, AllFiles, async () => false);
+        const gathered = [];
+        for await (const what of it) {
+            gathered.push(what);
+        }
+        assert.strictEqual(gathered.length,  0);
     });
 
     it("withFiles: run", done => {

--- a/test/project/util/projectUtils.test.ts
+++ b/test/project/util/projectUtils.test.ts
@@ -8,7 +8,8 @@ import {
     deleteFiles,
     doWithFiles,
     fileExists,
-    gatherFromFiles, iterateFiles,
+    gatherFromFiles,
+    iterateFiles,
 } from "../../../lib/project/util/projectUtils";
 import { tempProject } from "../utils";
 

--- a/test/tree/ast/astUtils.test.ts
+++ b/test/tree/ast/astUtils.test.ts
@@ -10,7 +10,10 @@ import {
     matchIterator,
     zapAllMatches,
 } from "../../../lib/tree/ast/astUtils";
-import { MatchResult, ZapTrailingWhitespace } from "../../../lib/tree/ast/FileHits";
+import {
+    MatchResult,
+    ZapTrailingWhitespace,
+} from "../../../lib/tree/ast/FileHits";
 import { TypeScriptES6FileParser } from "../../../lib/tree/ast/typescript/TypeScriptFileParser";
 
 describe("astUtils", () => {

--- a/test/tree/ast/astUtils.test.ts
+++ b/test/tree/ast/astUtils.test.ts
@@ -6,8 +6,8 @@ import { InMemoryProject } from "../../../lib/project/mem/InMemoryProject";
 import {
     findMatches,
     gatherFromMatches,
-    matchIterator,
     literalValues,
+    matchIterator,
     zapAllMatches,
 } from "../../../lib/tree/ast/astUtils";
 import { MatchResult, ZapTrailingWhitespace } from "../../../lib/tree/ast/FileHits";
@@ -45,7 +45,7 @@ describe("astUtils", () => {
                     parseWith: TypeScriptES6FileParser,
                     globPatterns: "src/**/*.ts",
                     pathExpression: "//VariableDeclaration[?check]/Identifier",
-                    functionRegistry: { check: n => n.$value.includes("x") }
+                    functionRegistry: { check: n => n.$value.includes("x") },
                 });
             let i = 0;
             for await (const match of matches) {

--- a/test/tree/ast/astUtils.test.ts
+++ b/test/tree/ast/astUtils.test.ts
@@ -5,7 +5,8 @@ import { InMemoryFile } from "../../../lib/project/mem/InMemoryFile";
 import { InMemoryProject } from "../../../lib/project/mem/InMemoryProject";
 import {
     findMatches,
-    gatherFromMatches, iterateMatches,
+    gatherFromMatches,
+    iterateMatches,
     literalValues,
     zapAllMatches,
 } from "../../../lib/tree/ast/astUtils";

--- a/test/tree/ast/astUtils.test.ts
+++ b/test/tree/ast/astUtils.test.ts
@@ -5,7 +5,8 @@ import { InMemoryFile } from "../../../lib/project/mem/InMemoryFile";
 import { InMemoryProject } from "../../../lib/project/mem/InMemoryProject";
 import {
     findMatches,
-    gatherFromMatches, literalValues,
+    gatherFromMatches,
+    literalValues,
     zapAllMatches,
 } from "../../../lib/tree/ast/astUtils";
 import { ZapTrailingWhitespace } from "../../../lib/tree/ast/FileHits";

--- a/test/tree/ast/astUtils.test.ts
+++ b/test/tree/ast/astUtils.test.ts
@@ -6,7 +6,7 @@ import { InMemoryProject } from "../../../lib/project/mem/InMemoryProject";
 import {
     findMatches,
     gatherFromMatches,
-    iterateMatches,
+    matchIterator,
     literalValues,
     zapAllMatches,
 } from "../../../lib/tree/ast/astUtils";
@@ -40,7 +40,7 @@ describe("astUtils", () => {
             const f = new InMemoryFile("src/test.ts",
                 "const x: number = 10; const y = 13; const xylophone = 3;");
             const p = InMemoryProject.of(f);
-            const matches = iterateMatches(p,
+            const matches = matchIterator(p,
                 TypeScriptES6FileParser,
                 "src/**/*.ts",
                 "//VariableDeclaration[?check]/Identifier",

--- a/test/tree/ast/astUtils.test.ts
+++ b/test/tree/ast/astUtils.test.ts
@@ -1,3 +1,4 @@
+import { toPathExpression } from "@atomist/tree-path";
 import "mocha";
 import * as assert from "power-assert";
 import { InMemoryFile } from "../../../lib/project/mem/InMemoryFile";
@@ -9,7 +10,6 @@ import {
 } from "../../../lib/tree/ast/astUtils";
 import { ZapTrailingWhitespace } from "../../../lib/tree/ast/FileHits";
 import { TypeScriptES6FileParser } from "../../../lib/tree/ast/typescript/TypeScriptFileParser";
-import { toPathExpression } from "@atomist/tree-path";
 
 describe("astUtils", () => {
 


### PR DESCRIPTION
Optimize, determining whether a file needs to be parsed based on literal value tests using string searches before invoking an actual FileParser.

When using expensive parsers such as ANTLR, this can increase performance by many times greatly reducing the number of files that need to be parsed.

Also add an optional method FileParser implementations can implement to provide further optimization.

Also adds async generator functions for project and AST operations. These can be more performant when we don't need all results, and when parsing is CPU bound so that parallel promise execution won't work.