### PR TITLE
Introduce `targets.branch` and fix `project.id` to point to correct project

### DIFF
--- a/lib/internal/transport/cluster/ClusterMasterRequestProcessor.ts
+++ b/lib/internal/transport/cluster/ClusterMasterRequestProcessor.ts
@@ -280,7 +280,7 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
 
     protected sendStatusMessage(payload: any, ctx: HandlerContext & AutomationContextAware): Promise<any> {
         return Promise.resolve(
-            this.webSocketLifecycle.send(payload)
+            this.webSocketLifecycle.send(payload),
         );
     }
 

--- a/lib/internal/transport/websocket/DefaultWebSocketRequestProcessor.ts
+++ b/lib/internal/transport/websocket/DefaultWebSocketRequestProcessor.ts
@@ -75,7 +75,7 @@ export class DefaultWebSocketRequestProcessor extends AbstractRequestProcessor
 
     protected sendStatusMessage(payload: any, ctx: HandlerContext & AutomationContextAware): Promise<any> {
         return Promise.resolve(
-            this.webSocketLifecycle.send(payload)
+            this.webSocketLifecycle.send(payload),
         );
     }
 

--- a/lib/internal/transport/websocket/WebSocketLifecycle.ts
+++ b/lib/internal/transport/websocket/WebSocketLifecycle.ts
@@ -70,9 +70,7 @@ export class WebSocketLifecycle {
             while (this.messages.length) {
                 queuedMessages.push(this.messages.pop());
             }
-            for (const queuedMessage of queuedMessages) {
-                await this.send(queuedMessage);
-            }
+            queuedMessages.forEach(this.send);
         }, 1000);
         this.timer.unref();
     }

--- a/lib/internal/transport/websocket/WebSocketLifecycle.ts
+++ b/lib/internal/transport/websocket/WebSocketLifecycle.ts
@@ -10,7 +10,7 @@ export class WebSocketLifecycle {
     private messages: TinyQueue;
     private ws: WebSocket;
     private timer: NodeJS.Timer;
-    
+
     constructor() {
         this.messages = new TinyQueue();
     }

--- a/lib/operations/common/params/AlwaysAskRepoParameters.ts
+++ b/lib/operations/common/params/AlwaysAskRepoParameters.ts
@@ -6,6 +6,7 @@ import { GitHubTargetsParams } from "./GitHubTargetsParams";
 import {
     GitBranchRegExp,
     GitHubNameRegExp,
+    GitShaRegExp,
 } from "./validationPatterns";
 
 /**
@@ -21,7 +22,10 @@ export class AlwaysAskRepoParameters extends GitHubTargetsParams {
     @Parameter({ description: "Name of repo to edit or regex", pattern: /.+/, required: true })
     public repo: string;
 
-    @Parameter({ description: "Branch or ref. Defaults to 'master'", ...GitBranchRegExp, required: false })
+    @Parameter({ description: "Ref", ...GitShaRegExp, required: false })
     public sha: string;
+
+    @Parameter({ description: "Branch Defaults to 'master'", ...GitBranchRegExp, required: false })
+    public branch: string = "master";
 
 }

--- a/lib/operations/common/params/GitHubFallbackReposParameters.ts
+++ b/lib/operations/common/params/GitHubFallbackReposParameters.ts
@@ -5,7 +5,10 @@ import {
 } from "../../../decorators";
 import { FallbackParams } from "./FallbackParams";
 import { GitHubTargetsParams } from "./GitHubTargetsParams";
-import { GitBranchRegExp } from "./validationPatterns";
+import {
+    GitBranchRegExp,
+    GitShaRegExp,
+} from "./validationPatterns";
 
 /**
  * Resolve from a Mapped parameter or from a supplied repos regex if no repo mapping
@@ -18,8 +21,11 @@ export class GitHubFallbackReposParameters extends GitHubTargetsParams implement
     @MappedParameter(MappedParameters.GitHubRepository, false)
     public repo: string;
 
-    @Parameter({ description: "Branch or ref. Defaults to 'master'", ...GitBranchRegExp, required: false })
-    public sha: string = "master";
+    @Parameter({ description: "Ref", ...GitShaRegExp, required: false })
+    public sha: string;
+
+    @Parameter({ description: "Branch Defaults to 'master'", ...GitBranchRegExp, required: false })
+    public branch: string = "master";
 
     @Parameter({ description: "regex", required: false })
     public repos: string = ".*";

--- a/lib/operations/common/params/GitHubTargetsParams.ts
+++ b/lib/operations/common/params/GitHubTargetsParams.ts
@@ -32,20 +32,16 @@ export abstract class GitHubTargetsParams extends TargetsParams {
         if (!this.owner || !this.repo || this.usesRegex) {
             return undefined;
         }
-        // sha is actually a ref (either sha or pointer)
-        const branch = isValidSHA1(this.sha) ? undefined : this.sha;
-        const sha = isValidSHA1(this.sha) ? this.sha : undefined;
-        return GitHubRepoRef.from({ owner: this.owner, repo: this.repo, sha, branch, rawApiBase: this.apiUrl });
+        return GitHubRepoRef.from({
+            owner: this.owner,
+            repo: this.repo,
+            sha: this.sha,
+            branch: this.branch,
+            rawApiBase: this.apiUrl,
+        });
     }
 
     @Secret(Secrets.userToken(["repo", "user:email", "read:user"]))
     private githubToken: string;
 
-}
-
-function isValidSHA1(s: string): boolean {
-    if (!s) {
-        return false;
-    }
-    return s.match(/[a-fA-F0-9]{40}/) != null;
 }

--- a/lib/operations/common/params/GitlabTargetsParams.ts
+++ b/lib/operations/common/params/GitlabTargetsParams.ts
@@ -9,7 +9,10 @@ import { GitlabPrivateTokenCredentials } from "../GitlabPrivateTokenCredentials"
 import { GitlabRepoRef } from "../GitlabRepoRef";
 import { ProjectOperationCredentials } from "../ProjectOperationCredentials";
 import { TargetsParams } from "./TargetsParams";
-import { GitBranchRegExp } from "./validationPatterns";
+import {
+    GitBranchRegExp,
+    GitShaRegExp,
+} from "./validationPatterns";
 
 @Parameters()
 export class GitlabTargetsParams extends TargetsParams {
@@ -26,12 +29,11 @@ export class GitlabTargetsParams extends TargetsParams {
     @MappedParameter(MappedParameters.GitHubUrl, false)
     public url: string;
 
-    @Parameter({
-        description: "Branch or ref. Defaults to 'master'",
-        ...GitBranchRegExp,
-        required: false,
-    })
-    public sha: string = "master";
+    @Parameter({ description: "Ref", ...GitShaRegExp, required: false })
+    public sha: string;
+
+    @Parameter({ description: "Branch Defaults to 'master'", ...GitBranchRegExp, required: false })
+    public branch: string = "master";
 
     @Parameter({ description: "regex", required: false })
     public repos: string = ".*";
@@ -62,6 +64,7 @@ export class GitlabTargetsParams extends TargetsParams {
                 owner: this.owner,
                 repo: this.repo,
                 sha: this.sha,
+                branch: this.branch,
                 rawApiBase: this.apiUrl,
                 gitlabRemoteUrl: this.url,
             }) :

--- a/lib/operations/common/params/MappedRepoParameters.ts
+++ b/lib/operations/common/params/MappedRepoParameters.ts
@@ -5,7 +5,10 @@ import {
     Parameters,
 } from "../../../decorators";
 import { GitHubTargetsParams } from "./GitHubTargetsParams";
-import { GitBranchRegExp } from "./validationPatterns";
+import {
+    GitBranchRegExp,
+    GitShaRegExp,
+} from "./validationPatterns";
 
 /**
  * Get target from channel mapping
@@ -19,7 +22,10 @@ export class MappedRepoParameters extends GitHubTargetsParams {
     @MappedParameter(MappedParameters.GitHubRepository)
     public repo: string;
 
-    @Parameter({ description: "Branch or ref. Defaults to 'master'", ...GitBranchRegExp, required: false })
+    @Parameter({ description: "Ref", ...GitShaRegExp, required: false })
     public sha: string;
+
+    @Parameter({ description: "Branch Defaults to 'master'", ...GitBranchRegExp, required: false })
+    public branch: string = "master";
 
 }

--- a/lib/operations/common/params/TargetsParams.ts
+++ b/lib/operations/common/params/TargetsParams.ts
@@ -23,6 +23,8 @@ export abstract class TargetsParams implements Credentialed, RemoteLocator {
 
     public abstract sha;
 
+    public abstract branch;
+
     public abstract credentials: ProjectOperationCredentials;
 
     get usesRegex() {

--- a/lib/operations/edit/editModes.ts
+++ b/lib/operations/edit/editModes.ts
@@ -104,8 +104,7 @@ export class PullRequest extends Commit {
                 public title: string,
                 public body: string = title,
                 public message: string = title,
-                // Make default to master for backwards-compatible reasons
-                public targetBranch: string = "master",
+                public targetBranch?: string,
                 public autoMerge?: AutoMerge) {
         super(branch, message, autoMerge);
     }

--- a/lib/operations/generate/generatorUtils.ts
+++ b/lib/operations/generate/generatorUtils.ts
@@ -1,5 +1,3 @@
-import * as fs from "fs-extra";
-import { newRepo } from "../../../test/api/apiUtils";
 import { ActionResult } from "../../action/ActionResult";
 import { HandlerContext } from "../../HandlerContext";
 import { GitProject } from "../../project/git/GitProject";
@@ -64,7 +62,11 @@ export function generate<P extends Project = Project, PARAMS = object>(
                         .then(independentCopy => release(seed).then(() => independentCopy)))
                 // Let's be sure we didn't inherit any old git stuff
                 .then(independentCopy => independentCopy.deleteDirectory(".git"))
-                .then(independentCopy => toEditor<PARAMS>(editor)(independentCopy, ctx, params))
+                .then(independentCopy => {
+                    // Overwrite the seed id before running the editor so that it sees the new repo details
+                    independentCopy.id = targetId;
+                    return toEditor<PARAMS>(editor)(independentCopy, ctx, params);
+                })
                 .then(r => r.target)
                 .then(populated => {
                     logger.debug("Persisting repo at [%s]: owner/repo=%s/%s",

--- a/test/operations/generate/generatorUtils.test.ts
+++ b/test/operations/generate/generatorUtils.test.ts
@@ -5,6 +5,7 @@ import {
     ActionResult,
     successOn,
 } from "../../../lib/action/ActionResult";
+import { GitHubSourceRepoParameters } from "../../../lib/operations/common/params/GitHubSourceRepoParameters";
 import { ProjectOperationCredentials } from "../../../lib/operations/common/ProjectOperationCredentials";
 import {
     RepoId,
@@ -15,6 +16,7 @@ import {
     generate,
     ProjectPersister,
 } from "../../../lib/operations/generate/generatorUtils";
+import { GitHubRepoCreationParameters } from "../../../lib/operations/generate/GitHubRepoCreationParameters";
 import { InMemoryProject } from "../../../lib/project/mem/InMemoryProject";
 import { Project } from "../../../lib/project/Project";
 
@@ -51,6 +53,23 @@ describe("generatorUtils", () => {
             null, null,
             (p, ctx, parms) => {
                 assert(parms === params);
+                return Promise.resolve(p);
+            },
+            mockProjectPersister,
+            new SimpleRepoId("foo", "bar"),
+            params,
+        )
+            .then(() => done(), done);
+    });
+
+    it("sees correct target repo id", done => {
+        const params = new BaseSeedDrivenGeneratorParameters();
+        generate(InMemoryProject.of(),
+            null, null,
+            (p, ctx, parms) => {
+                assert(parms === params);
+                assert.strictEqual(p.id.owner, "foo");
+                assert.strictEqual(p.id.repo, "bar");
                 return Promise.resolve(p);
             },
             mockProjectPersister,


### PR DESCRIPTION
Introduce `targets.branch` to instruct a `CodeTransform` to work off of a branch.

Fix `project.id` as 1st parameter to a `CodeTransform` to always point to the correct repo; and not - in the case of project creation - to the local cloned seed repo.

Removed default to merge into `master` for `PullRequest` edit mode.