### PR TITLE
Allow matchIterator to be used to change matches

### DIFF
--- a/test/tree/ast/astUtils.test.ts
+++ b/test/tree/ast/astUtils.test.ts
@@ -172,7 +172,7 @@ describe("astUtils", () => {
             assert.deepEqual(matches, ["x"]);
         });
 
-        it.skip("matchIterator: modify simple and jump out", async () => {
+        it("matchIterator: modify simple and jump out", async () => {
             const f = new InMemoryFile("src/test.ts",
                 "const x: number = 10; const y = 13; const xylophone = 3;");
             const p = InMemoryProject.of(f);


### PR DESCRIPTION
`matchIterator` can now be used to change matches, even if a caller jumps out of the generator while iterating.

Also slight refactoring to use async/await.