### PR TITLE
Add support for contextual suppression of matches using path expressions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -48,6 +48,7 @@ import * as parseUtils from "./lib/project/util/parseUtils";
 import * as projectUtils from "./lib/project/util/projectUtils";
 import * as secured from "./lib/secured";
 import * as astUtils from "./lib/tree/ast/astUtils";
+import * as matchTesters from "./lib/tree/ast/matchTesters";
 
 export { GraphQL };
 export {
@@ -226,6 +227,8 @@ export * from "./lib/spi/http/curlHttpClient";
 export * from "./lib/spi/http/httpClient";
 export * from "./lib/spi/message/MessageClient";
 export { astUtils };
+export { matchTesters };
+
 export {
     MatchResult,
     ZapTrailingWhitespace,

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -40,6 +40,10 @@ import {
 } from "./FileParser";
 import { FileParserRegistry } from "./FileParserRegistry";
 
+/**
+ * Create a MatchTester to use against this file, caching
+ * any parsed or otherwise computed resources.
+ */
 export type MatchTesterMaker = (f: File) => Promise<MatchTester>;
 
 /**
@@ -81,7 +85,7 @@ export interface PathExpressionQueryOptions {
 }
 
 /**
- * Tests matches within this file
+ * Tests matches within this file, using their tree node basis.
  */
 export type MatchTester = (n: LocatedTreeNode) => boolean;
 

--- a/lib/tree/ast/matchTesters.ts
+++ b/lib/tree/ast/matchTesters.ts
@@ -1,6 +1,6 @@
 import { Microgrammar } from "@atomist/microgrammar";
-import { MatchTesterMaker } from "./astUtils";
 import { PatternMatch } from "@atomist/microgrammar/lib/PatternMatch";
+import { MatchTesterMaker } from "./astUtils";
 
 /**
  * Exclude matches that are within a match of the given microgrammar

--- a/lib/tree/ast/matchTesters.ts
+++ b/lib/tree/ast/matchTesters.ts
@@ -1,0 +1,20 @@
+import { Microgrammar } from "@atomist/microgrammar";
+import { MatchTesterMaker } from "./astUtils";
+import { PatternMatch } from "@atomist/microgrammar/lib/PatternMatch";
+
+/**
+ * Exclude matches that are within a match of the given microgrammar
+ * @param {Microgrammar<any>} mg
+ * @return {MatchTesterMaker}
+ */
+export function notWithin(mg: Microgrammar<any>): MatchTesterMaker {
+    return async file => {
+        const content = await file.getContent();
+        const matches: PatternMatch[] = mg.findMatches(content);
+        return n => !matches.some(m => {
+            const mEndoffset = m.$offset + m.$matched.length;
+            const nEndoffset = n.$offset + n.$value.length;
+            return m.$offset <= n.$offset && mEndoffset >= nEndoffset;
+        });
+    };
+}

--- a/test/tree/ast/microgrammar/microgrammars.test.ts
+++ b/test/tree/ast/microgrammar/microgrammars.test.ts
@@ -11,10 +11,10 @@ import {
     findFileMatches,
     findMatches, matchIterator,
 } from "../../../../lib/tree/ast/astUtils";
-import { DefaultFileParserRegistry } from "../../../../lib/tree/ast/FileParserRegistry";
-import { MicrogrammarBasedFileParser } from "../../../../lib/tree/ast/microgrammar/MicrogrammarBasedFileParser";
 import { MatchResult } from "../../../../lib/tree/ast/FileHits";
+import { DefaultFileParserRegistry } from "../../../../lib/tree/ast/FileParserRegistry";
 import { notWithin } from "../../../../lib/tree/ast/matchTesters";
+import { MicrogrammarBasedFileParser } from "../../../../lib/tree/ast/microgrammar/MicrogrammarBasedFileParser";
 
 interface Person {
     name: string;

--- a/test/tree/ast/microgrammar/microgrammars.test.ts
+++ b/test/tree/ast/microgrammar/microgrammars.test.ts
@@ -9,7 +9,8 @@ import { AllFiles } from "../../../../lib/project/fileGlobs";
 import { InMemoryProject } from "../../../../lib/project/mem/InMemoryProject";
 import {
     findFileMatches,
-    findMatches, matchIterator,
+    findMatches,
+    matchIterator,
 } from "../../../../lib/tree/ast/astUtils";
 import { MatchResult } from "../../../../lib/tree/ast/FileHits";
 import { DefaultFileParserRegistry } from "../../../../lib/tree/ast/FileParserRegistry";


### PR DESCRIPTION
Newer path expression functions now allow the use of a "match tester," which allows some matches to be excluded. This allows contextual decision making, as in using the new `notWithin` function to excluded matches within another type of match.

The following test shows usage and its effect:

```typescript
it("should exclude with notWithin MatchTester", async () => {
        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
            age: Integer,
        });
        const file = Microgrammar.fromDefinitions<{ first: Person, second: Person }>({
            first: mg,
            second: mg,
        });
        const parseWith = new MicrogrammarBasedFileParser("people", "pair", file);
        const p = InMemoryProject.of(
            { path: "Thing1", content: "Tom:16 Mary:25" },
            { path: "Thing2", content: "George:16 Kathy:25" },
        );
        const it = matchIterator(p, {
            parseWith,
            globPatterns: AllFiles,
            pathExpression: "//pair//name",
            testWith: notWithin(Microgrammar.fromDefinitions({
                badName: /[A-Za-z]+:25/,
            })),
        });
        const matches: MatchResult[] = [];
        for await (const match of it) {
            matches.push(match);
        }
        assert.strictEqual(matches.length, 2);
        assert.strictEqual(matches[0].$value, "Tom");
        assert.strictEqual(matches[1].$value, "George");
    });
```
