### PR TITLE
Allow path expressions to be backed by regular expressions with capture groups

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -243,6 +243,12 @@ export {
     TypeScriptES6FileParser,
 } from "./lib/tree/ast/typescript/TypeScriptFileParser";
 export {
+    MicrogrammarBasedFileParser,
+} from "./lib/tree/ast/microgrammar/MicrogrammarBasedFileParser";
+export {
+    RegexFileParser,
+} from "./lib/tree/ast/regex/RegexFileParser";
+export {
     WritableLog,
 } from "./lib/util/child_process";
 export * from "./lib/util/exec";

--- a/lib/tree/ast/microgrammar/MicrogrammarBasedFileParser.ts
+++ b/lib/tree/ast/microgrammar/MicrogrammarBasedFileParser.ts
@@ -17,9 +17,9 @@ import { FileParser } from "../FileParser";
  */
 export class MicrogrammarBasedFileParser implements FileParser {
 
-    constructor(public rootName: string,
-                public matchName: string,
-                public grammar: Microgrammar<any>) {
+    constructor(public readonly rootName: string,
+                public readonly matchName: string,
+                public readonly grammar: Microgrammar<any>) {
     }
 
     public async toAst(f: File): Promise<TreeNode> {

--- a/lib/tree/ast/microgrammar/MicrogrammarBasedFileParser.ts
+++ b/lib/tree/ast/microgrammar/MicrogrammarBasedFileParser.ts
@@ -17,6 +17,12 @@ import { FileParser } from "../FileParser";
  */
 export class MicrogrammarBasedFileParser implements FileParser {
 
+    /**
+     * Create a new MicrogrammarBasedFileParser, around a single microgrammar
+     * @param {string} rootName name of the root element
+     * @param {string} matchName name of each match
+     * @param {Microgrammar<any>} grammar
+     */
     constructor(public readonly rootName: string,
                 public readonly matchName: string,
                 public readonly grammar: Microgrammar<any>) {

--- a/lib/tree/ast/regex/RegexFileParser.ts
+++ b/lib/tree/ast/regex/RegexFileParser.ts
@@ -1,4 +1,8 @@
-import { defineDynamicProperties, fillInEmptyNonTerminalValues, TreeNode } from "@atomist/tree-path";
+import {
+    defineDynamicProperties,
+    fillInEmptyNonTerminalValues,
+    TreeNode,
+} from "@atomist/tree-path";
 
 import { File } from "../../../project/File";
 import { FileParser } from "../FileParser";

--- a/lib/tree/ast/regex/RegexFileParser.ts
+++ b/lib/tree/ast/regex/RegexFileParser.ts
@@ -1,0 +1,75 @@
+import { defineDynamicProperties, fillInEmptyNonTerminalValues, TreeNode } from "@atomist/tree-path";
+
+import { File } from "../../../project/File";
+import { FileParser } from "../FileParser";
+
+export interface RegexOptions {
+    readonly rootName: string;
+    readonly matchName: string;
+    readonly regex: RegExp;
+    readonly captureGroupNames: string[];
+}
+
+/**
+ * Allow path expressions against results from a regex with capture groups
+ */
+export class RegexFileParser implements FileParser {
+
+    constructor(public readonly opts: RegexOptions) {
+    }
+
+    get rootName(): string {
+        return this.opts.rootName;
+    }
+
+    public async toAst(f: File): Promise<TreeNode> {
+        const content = await f.getContent();
+        const matches: RegExpExecArray[] = [];
+        let remaining = content;
+        do {
+            const m = this.opts.regex.exec(remaining);
+            if (!!m) {
+                matches.push(m);
+                // Rewrite index in outer string
+                m.index += content.length - remaining.length;
+                remaining = content.substr(m.index + m[0].length);
+            } else {
+                break;
+            }
+        } while (true);
+        const root: TreeNode = {
+            $name: this.opts.rootName,
+        };
+        root.$children = matches.map(match => new RegexTreeNode(this.opts, match, root));
+
+        defineDynamicProperties(root);
+        fillInEmptyNonTerminalValues(root, content);
+        return root;
+    }
+}
+
+class RegexTreeNode implements TreeNode {
+
+    public readonly $children: TreeNode[];
+
+    public readonly $name: string;
+
+    public readonly $value: string;
+
+    public readonly $offset: number;
+
+    constructor(reo: RegexOptions, m: RegExpExecArray, public $parent: TreeNode) {
+        this.$name = reo.matchName;
+        this.$offset = m.index;
+        this.$value = m[0];
+        this.$children = reo.captureGroupNames.map(($name, i) => {
+            const tn: any = {
+                $name,
+                $value: m[i + 1],
+            };
+            tn.$offset = m.index + m[0].indexOf(tn.$value);
+            return tn;
+        });
+    }
+
+}

--- a/lib/tree/ast/regex/RegexFileParser.ts
+++ b/lib/tree/ast/regex/RegexFileParser.ts
@@ -3,11 +3,30 @@ import { defineDynamicProperties, fillInEmptyNonTerminalValues, TreeNode } from 
 import { File } from "../../../project/File";
 import { FileParser } from "../FileParser";
 
+/**
+ * Parameters to RegexFileParser
+ */
 export interface RegexOptions {
+
+    /**
+     * Name of the root element within a document
+     */
     readonly rootName: string;
+
+    /**
+     * Path element name for each match
+     */
     readonly matchName: string;
+
+    /**
+     * Regex. May contain capture groups: If so name them with captureGroupNames.
+     */
     readonly regex: RegExp;
-    readonly captureGroupNames: string[];
+
+    /**
+     * Names of the capture groups, if any. This is used to populate the tree structure.
+     */
+    readonly captureGroupNames?: string[];
 }
 
 /**
@@ -62,14 +81,16 @@ class RegexTreeNode implements TreeNode {
         this.$name = reo.matchName;
         this.$offset = m.index;
         this.$value = m[0];
-        this.$children = reo.captureGroupNames.map(($name, i) => {
-            const tn: any = {
-                $name,
-                $value: m[i + 1],
-            };
-            tn.$offset = m.index + m[0].indexOf(tn.$value);
-            return tn;
-        });
+        this.$children = !!reo.captureGroupNames ?
+            reo.captureGroupNames.map(($name, i) => {
+                const tn: any = {
+                    $name,
+                    $value: m[i + 1],
+                };
+                tn.$offset = m.index + m[0].indexOf(tn.$value);
+                return tn;
+            }) :
+            undefined;
     }
 
 }

--- a/test/tree/ast/regex/RegexFileParser.test.ts
+++ b/test/tree/ast/regex/RegexFileParser.test.ts
@@ -1,11 +1,11 @@
-import { TreeNode, } from "@atomist/tree-path";
+import { TreeNode } from "@atomist/tree-path";
 import "mocha";
 import * as assert from "power-assert";
-import { InMemoryFile } from "../../../../lib/project/mem/InMemoryFile";
-import { RegexFileParser } from "../../../../lib/tree/ast/regex/RegexFileParser";
-import { findMatches } from "../../../../lib/tree/ast/astUtils";
-import { InMemoryProject } from "../../../../lib/project/mem/InMemoryProject";
 import { AllFiles } from "../../../../lib/project/fileGlobs";
+import { InMemoryFile } from "../../../../lib/project/mem/InMemoryFile";
+import { InMemoryProject } from "../../../../lib/project/mem/InMemoryProject";
+import { findMatches } from "../../../../lib/tree/ast/astUtils";
+import { RegexFileParser } from "../../../../lib/tree/ast/regex/RegexFileParser";
 
 interface Person {
     name: string;

--- a/test/tree/ast/regex/RegexFileParser.test.ts
+++ b/test/tree/ast/regex/RegexFileParser.test.ts
@@ -34,6 +34,22 @@ describe("RegexFileParser", () => {
         assert.strictEqual(tom.age, "16");
     });
 
+    it("should parse a file without capture groups", async () => {
+        const personParserNoCapture = new RegexFileParser({
+            rootName: "people",
+            matchName: "person",
+            regex: /[A-z][a-z]+:[\d]+/,
+        });
+        const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
+        const root = await personParserNoCapture.toAst(f);
+        assert(root.$name === "people");
+        assert(root.$children.length === 2);
+        const tom = root.$children[0] as TreeNode;
+        assert(tom.$name === "person");
+        assert.strictEqual(tom.$value, "Tom:16");
+        assert.strictEqual(tom.$children, undefined);
+    });
+
     it("exposes source locations", async () => {
         const content = "Tom:16 Mary:25";
         const p = InMemoryProject.of(

--- a/test/tree/ast/regex/RegexFileParser.test.ts
+++ b/test/tree/ast/regex/RegexFileParser.test.ts
@@ -1,0 +1,82 @@
+import { TreeNode, } from "@atomist/tree-path";
+import "mocha";
+import * as assert from "power-assert";
+import { InMemoryFile } from "../../../../lib/project/mem/InMemoryFile";
+import { RegexFileParser } from "../../../../lib/tree/ast/regex/RegexFileParser";
+import { findMatches } from "../../../../lib/tree/ast/astUtils";
+import { InMemoryProject } from "../../../../lib/project/mem/InMemoryProject";
+import { AllFiles } from "../../../../lib/project/fileGlobs";
+
+interface Person {
+    name: string;
+    age: number;
+}
+
+const personParser = new RegexFileParser({
+    rootName: "people",
+    matchName: "person",
+    regex: /([A-z][a-z]+):([\d]+)/,
+    captureGroupNames: ["name", "age"],
+});
+
+describe("RegexFileParser", () => {
+
+    it("should parse a file", async () => {
+        const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
+        const root = await personParser.toAst(f);
+        assert(root.$name === "people");
+        assert(root.$children.length === 2);
+        const tom = root.$children[0] as TreeNode & Person;
+        assert(tom.$name === "person");
+        assert.strictEqual(tom.$value, "Tom:16");
+        assert.strictEqual(tom.$children.length, 2);
+        assert.strictEqual(tom.name, "Tom");
+        assert.strictEqual(tom.age, "16");
+    });
+
+    it("exposes source locations", async () => {
+        const content = "Tom:16 Mary:25";
+        const p = InMemoryProject.of(
+            { path: "Thing", content });
+        const matches = await findMatches<Person>(p, personParser, AllFiles, "/people/person/name");
+        assert(matches.length === 2);
+        assert(matches[0].$value === "Tom");
+        assert(matches[1].$value === "Mary");
+        matches.forEach(m => {
+            assert(!!m.sourceLocation);
+            assert(m.sourceLocation.path === "Thing");
+            assert(m.sourceLocation.offset === m.$offset);
+            assert.notStrictEqual(m.sourceLocation.offset, undefined);
+            assert(content.substring(m.sourceLocation.offset).startsWith(m.$value),
+                `Offset was ${m.sourceLocation.offset} and content was '${m.$value}'`);
+        });
+    });
+
+    it("exposes source locations one down", async () => {
+        const content = "Tom:16 Mary:25";
+        const p = InMemoryProject.of(
+            { path: "Thing", content });
+        const matches = await findMatches<Person>(p, personParser, AllFiles, "/people/person");
+        assert(matches.length === 2);
+        assert(matches[0].$value === "Tom:16");
+        const tom = matches[0];
+        assert.strictEqual("Tom", tom.name);
+        assert.strictEqual(tom.$children[0].$offset, 0);
+        assert.strictEqual(tom.$children[1].$offset, 4);
+        const mary = matches[1];
+        assert.strictEqual("Mary", mary.name);
+        assert.strictEqual(mary.$children[0].$offset, 7);
+        assert.strictEqual(mary.$children[1].$offset, 12);
+        assert(matches[1].$value === "Mary:25");
+        matches.forEach(m => {
+            assert(!!m.sourceLocation);
+            assert(m.sourceLocation.path === "Thing");
+            assert(m.sourceLocation.offset === m.$offset);
+            assert.notStrictEqual(m.sourceLocation.offset, undefined);
+            assert(content.substring(m.sourceLocation.offset).startsWith(m.$value),
+                `Offset was ${m.sourceLocation.offset} and content was '${m.$value}'`);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Similar to microgrammar based parsers, make it possible to match and destructure regular expression groups using path expressions. For example:

```typescript
const personParser = new RegexFileParser({
    rootName: "people",
    matchName: "person",
    regex: /([A-z][a-z]+):([\d]+)/,
    captureGroupNames: ["name", "age"],
});

const matches = await findMatches<Person>(p, personParser, AllFiles, "/people/person/name");
```