### PR TITLE
Upgrade tree-path and microgrammar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,9 @@
       }
     },
     "@atomist/microgrammar": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.0.1.tgz",
-      "integrity": "sha512-XJA+QzCSVRb8TV0oxlMHUbyHxQTbXKwh3Z5yus491W2SvBn6GvR9nM7CoDXhNfb2KBGm2TVV2Lx93yOPnqtq5g=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.0.3.tgz",
+      "integrity": "sha512-XCtu0nnk5tiDMYsBv+hKNC3zbTIKY8mC4d634y4+XUX38FqXMm9TGSSWGeUL3/jL7uai09Gs3L9JfDUep3838A=="
     },
     "@atomist/slack-messages": {
       "version": "1.1.0",
@@ -54,12 +54,12 @@
       "integrity": "sha512-sai3gxAyFXVBa7A7AADdVcO8Nw0gV+bXHY9T4Ki447gqbMpAyyVj3V2qxY6wmdI9j5EcwPl0fOaBpFN3xEJTkw=="
     },
     "@atomist/tree-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@atomist/tree-path/-/tree-path-1.0.1.tgz",
-      "integrity": "sha512-RAEU7Nt4d8QCMJvlmBjjAq7gvV5qQPfD67W9pVER8ULYo+vFq/rVBS3O3ubGggm0Dd0hA6W/4ecOmgGN+u6Jog==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@atomist/tree-path/-/tree-path-1.0.2.tgz",
+      "integrity": "sha512-wP0Pw9+yCKjXGhaEmyNu6uEYpkXJZSH88bfGvGYMImfBAJ5MiSjQ9gvlKfyFGqVGkUN8F4XDEruwCwfxpxiQOw==",
       "requires": {
-        "@atomist/microgrammar": "1.0.1",
-        "@types/lodash": "^4.14.116",
+        "@atomist/microgrammar": "^1.0.3",
+        "@types/lodash": "^4.14.119",
         "lodash": "^4.17.10"
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {
-    "@atomist/microgrammar": "1.0.1",
+    "@atomist/microgrammar": "^1.0.3",
     "@atomist/slack-messages": "1.1.0",
-    "@atomist/tree-path": "1.0.1",
+    "@atomist/tree-path": "1.0.2",
     "@octokit/rest": "^16.3.0",
     "@typed/curry": "^1.0.1",
     "@types/app-root-path": "^1.2.4",

--- a/test/tree/ast/microgrammar/MicrogrammarBasedFileParser.test.ts
+++ b/test/tree/ast/microgrammar/MicrogrammarBasedFileParser.test.ts
@@ -1,6 +1,7 @@
 import {
     Integer,
     Microgrammar,
+    takeUntil,
 } from "@atomist/microgrammar";
 import {
     TreeNode,
@@ -19,7 +20,7 @@ interface Person {
 
 
 const nameAndAgeTerms = {
-    name: /.*/,
+    name: takeUntil(":"),
     age: Integer,
 };
 
@@ -87,10 +88,10 @@ describe("MicrogrammarBasedFileParser", () => {
     it("should parse a file and allow array navigation via property with a nested grammar", done => {
         const f = new InMemoryFile("Family", "Linda:[2007, mushrooms] Evelyn:[2005, sugar]");
         const mg = Microgrammar.fromString<Kid>("${name}:${fact}", {
-            name: /.*/,
+            name: takeUntil(":"),
             fact: Microgrammar.fromString<KidFact>("[${birthYear},${food}]", {
-                food: /.*/,
                 birthYear: Integer,
+                food: takeUntil("]"),
             }),
         });
         new MicrogrammarBasedFileParser("family", "kid", mg)

--- a/test/tree/ast/microgrammar/MicrogrammarBasedFileParser.test.ts
+++ b/test/tree/ast/microgrammar/MicrogrammarBasedFileParser.test.ts
@@ -17,13 +17,17 @@ interface Person {
     age: number;
 }
 
+
+const nameAndAgeTerms = {
+    name: /.*/,
+    age: Integer,
+};
+
 describe("MicrogrammarBasedFileParser", () => {
 
     it("should parse a file", done => {
         const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         new MicrogrammarBasedFileParser("people", "person", mg)
             .toAst(f)
             .then(root => {
@@ -38,9 +42,7 @@ describe("MicrogrammarBasedFileParser", () => {
 
     it("should parse a file and allow scalar navigation via property", done => {
         const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         new MicrogrammarBasedFileParser("people", "person", mg)
             .toAst(f)
             .then(root => {
@@ -56,9 +58,7 @@ describe("MicrogrammarBasedFileParser", () => {
 
     it("should parse a file and allow array navigation via property", done => {
         const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         new MicrogrammarBasedFileParser("people", "person", mg)
             .toAst(f)
             .then(root => {
@@ -87,7 +87,9 @@ describe("MicrogrammarBasedFileParser", () => {
     it("should parse a file and allow array navigation via property with a nested grammar", done => {
         const f = new InMemoryFile("Family", "Linda:[2007, mushrooms] Evelyn:[2005, sugar]");
         const mg = Microgrammar.fromString<Kid>("${name}:${fact}", {
+            name: /.*/,
             fact: Microgrammar.fromString<KidFact>("[${birthYear},${food}]", {
+                food: /.*/,
                 birthYear: Integer,
             }),
         });
@@ -108,9 +110,7 @@ describe("MicrogrammarBasedFileParser", () => {
 
     it("should parse a file and keep positions", done => {
         const f = new InMemoryFile("Thing", "Tom:16 Mary:25");
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         new MicrogrammarBasedFileParser("people", "person", mg)
             .toAst(f)
             .then(root => {

--- a/test/tree/ast/microgrammar/microgrammars.test.ts
+++ b/test/tree/ast/microgrammar/microgrammars.test.ts
@@ -22,12 +22,15 @@ interface Person {
     age: number;
 }
 
+const nameAndAgeTerms = {
+    name: /.*/,
+    age: Integer,
+};
+
 describe("microgrammar integration and path expression", () => {
 
     it("should get into AST", done => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const fpr = new DefaultFileParserRegistry().addParser(
             new MicrogrammarBasedFileParser("people", "person", mg));
         const p = InMemoryProject.of(
@@ -41,9 +44,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("should get into AST with strong typing", done => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const fpr = new DefaultFileParserRegistry().addParser(
             new MicrogrammarBasedFileParser("people", "person", mg));
         const p = InMemoryProject.of(
@@ -57,9 +58,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("should get into AST with strong typing and conversion", done => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
 
         // This type is correct here
         const m = mg.firstMatch("Tom:16");
@@ -79,9 +78,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("exposes source locations", done => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const fpr = new DefaultFileParserRegistry().addParser(
             new MicrogrammarBasedFileParser("people", "person", mg));
         const p = InMemoryProject.of(
@@ -100,9 +97,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("retains AST in file matches", done => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const fpr = new DefaultFileParserRegistry().addParser(
             new MicrogrammarBasedFileParser("people", "person", mg));
         const p = InMemoryProject.of(
@@ -119,9 +114,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("enable within check using path expression", done => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const file = Microgrammar.fromDefinitions<{ first: Person, second: Person }>({
             first: mg,
             second: mg,
@@ -154,9 +147,7 @@ describe("microgrammar integration and path expression", () => {
     }
 
     it("should get into AST and update single terminal", done => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const fpr = new DefaultFileParserRegistry().addParser(
             new MicrogrammarBasedFileParser("people", "person", mg));
         const p = InMemoryProject.of(
@@ -174,9 +165,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("should get into AST and update two terminals", done => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const fpr = new DefaultFileParserRegistry().addParser(
             new MicrogrammarBasedFileParser("people", "person", mg));
         const p = InMemoryProject.of(
@@ -195,9 +184,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("should get into AST and update single non-terminal", done => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const fpr = new DefaultFileParserRegistry().addParser(
             new MicrogrammarBasedFileParser("people", "person", mg));
         const firstPerson = "Tom:16";
@@ -219,9 +206,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("should get into AST and add content after non-terminal", done => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const fpr = new DefaultFileParserRegistry().addParser(
             new MicrogrammarBasedFileParser("people", "person", mg));
         const firstPerson = "Tom:16";
@@ -243,9 +228,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("should get into AST and add content before non-terminal", done => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const fpr = new DefaultFileParserRegistry().addParser(
             new MicrogrammarBasedFileParser("people", "person", mg));
         const firstPerson = "Tom:16";
@@ -267,9 +250,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("should allow predicate on file", done => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const fpr = new DefaultFileParserRegistry().addParser(
             new MicrogrammarBasedFileParser("people", "person", mg));
         const p = InMemoryProject.of(
@@ -285,9 +266,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("should veto with MatchTester", async () => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const file = Microgrammar.fromDefinitions<{ first: Person, second: Person }>({
             first: mg,
             second: mg,
@@ -311,9 +290,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("should veto every second with MatchTester", async () => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const file = Microgrammar.fromDefinitions<{ first: Person, second: Person }>({
             first: mg,
             second: mg,
@@ -338,9 +315,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("should exclude with notWithin MatchTester", async () => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const file = Microgrammar.fromDefinitions<{ first: Person, second: Person }>({
             first: mg,
             second: mg,
@@ -368,9 +343,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("should not exclude with irrelevant notWithin MatchTester", async () => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const file = Microgrammar.fromDefinitions<{ first: Person, second: Person }>({
             first: mg,
             second: mg,
@@ -396,9 +369,7 @@ describe("microgrammar integration and path expression", () => {
     });
 
     it("should allow typing", async () => {
-        const mg = Microgrammar.fromString<Person>("${name}:${age}", {
-            age: Integer,
-        });
+        const mg = Microgrammar.fromString<Person>("${name}:${age}", nameAndAgeTerms);
         const file = Microgrammar.fromDefinitions<{ first: Person, second: Person }>({
             first: mg,
             second: mg,

--- a/test/tree/ast/microgrammar/microgrammars.test.ts
+++ b/test/tree/ast/microgrammar/microgrammars.test.ts
@@ -1,6 +1,7 @@
 import {
     Integer,
     Microgrammar,
+    takeUntil,
 } from "@atomist/microgrammar";
 import { TreeNode } from "@atomist/tree-path";
 import "mocha";
@@ -23,7 +24,7 @@ interface Person {
 }
 
 const nameAndAgeTerms = {
-    name: /.*/,
+    name: takeUntil(":"),
     age: Integer,
 };
 


### PR DESCRIPTION
the goal is to get to microgrammar 1.0.3, with no 1.0.1 on the path, so that
we can allow SDMs to upgrade. 1.0.3 has a fix to remove Concat (class with
a private field) from the Microgrammar type, so that there isn't a conflict
between minor versions of the Microgrammar type.
Until then we get compile errors on any version of Microgrammar except precisely the one client uses.