### PR TITLE
Update failure logging for failed repo creations

### DIFF
--- a/lib/operations/generate/remoteGitProjectPersister.ts
+++ b/lib/operations/generate/remoteGitProjectPersister.ts
@@ -48,7 +48,7 @@ export const RemoteGitProjectPersister: ProjectPersister<GitProject> =
                     description, visibility)
                     .catch(err => {
                         return Promise.reject(new Error(`Unable to create new repo '${targetId.owner}/${targetId.repo}': ` +
-                            `Probably exists: ${err}`));
+                            `Error: ${err}`));
                     });
             })
             .then(() => {

--- a/test/api/generatorEndToEnd.test.ts
+++ b/test/api/generatorEndToEnd.test.ts
@@ -68,7 +68,7 @@ describe("generator end to end", () => {
             assert.fail("Should not have succeeded");
         } catch (e) {
             await fs.remove(clonedSeed.baseDir);
-            assert(e.message.includes("exists")); // this is only because we put "Probably exists" in the string
+            assert(e.message.includes("Unable to create new repo")); // testing to make sure we recieve the error message we raise
         }
     }).timeout(20000);
 


### PR DESCRIPTION
Prior to this commit their was always a message that said 'Probably
exists' when a new repo failed to create from a generator.  This was
misleading when the errors where coming from something like an
authorization problem (401).  Updated to make it more generic and let
the `err` object provide the detail.