### PR TITLE
Accept the interface Grammar, not the specific class

### DIFF
--- a/lib/project/util/parseUtils.ts
+++ b/lib/project/util/parseUtils.ts
@@ -1,4 +1,4 @@
-import { Microgrammar } from "@atomist/microgrammar";
+import { Grammar, Microgrammar } from "@atomist/microgrammar";
 import { PatternMatch } from "@atomist/microgrammar/lib/PatternMatch";
 import { ScriptedFlushable } from "../../internal/common/Flushable";
 import { logger } from "../../util/logger";
@@ -61,9 +61,9 @@ export const DefaultOpts: Opts = {
  * @param opts options
  */
 export function findMatches<M>(p: ProjectAsync,
-                               globPatterns: GlobOptions,
-                               microgrammar: Microgrammar<M>,
-                               opts: Opts = DefaultOpts): Promise<Array<Match<M>>> {
+    globPatterns: GlobOptions,
+    microgrammar: Grammar<M>,
+    opts: Opts = DefaultOpts): Promise<Array<Match<M>>> {
     return findFileMatches(p, globPatterns, microgrammar, opts)
         .then(fileHits => {
             let matches: Array<Match<M>> = [];
@@ -80,13 +80,13 @@ export function findMatches<M>(p: ProjectAsync,
  * @param opts options
  */
 export function findFileMatches<M>(p: ProjectAsync,
-                                   globPatterns: GlobOptions,
-                                   microgrammar: Microgrammar<M>,
-                                   opts: Opts = DefaultOpts): Promise<Array<FileWithMatches<M>>> {
+    globPatterns: GlobOptions,
+    microgrammar: Grammar<M>,
+    opts: Opts = DefaultOpts): Promise<Array<FileWithMatches<M>>> {
     return gatherFromFiles(p, globPatterns, file => {
         return file.getContent()
             .then(async content => {
-                const matches = await microgrammar.findMatchesAsync(transformIfNecessary(content, opts));
+                const matches = await microgrammar.findMatches(transformIfNecessary(content, opts));
                 if (matches.length > 0) {
                     logger.debug(`${matches.length} matches in '${file.path}'`);
                     return new UpdatingFileHits(p, file, matches, content);
@@ -102,19 +102,19 @@ export function findFileMatches<M>(p: ProjectAsync,
  * Manipulate each file match containing an actual match. Will automatically match if necessary.
  * @param p project
  * @param {string} globPatterns
- * @param {Microgrammar<M>} microgrammar
+ * @param {Grammar<M>} microgrammar
  * @param {(fh: FileWithMatches<M>) => void} action
  * @param opts options
  */
 export function doWithFileMatches<M, P extends ProjectAsync = ProjectAsync>(p: P,
-                                                                            globPatterns: GlobOptions,
-                                                                            microgrammar: Microgrammar<M>,
-                                                                            action: (fh: FileWithMatches<M>) => void,
-                                                                            opts: Opts = DefaultOpts): Promise<P> {
+    globPatterns: GlobOptions,
+    microgrammar: Grammar<M>,
+    action: (fh: FileWithMatches<M>) => void,
+    opts: Opts = DefaultOpts): Promise<P> {
     return doWithFiles(p, globPatterns, file => {
         return file.getContent()
             .then(async content => {
-                const matches = await microgrammar.findMatchesAsync(transformIfNecessary(content, opts));
+                const matches = await microgrammar.findMatches(transformIfNecessary(content, opts));
                 if (matches && matches.length > 0) {
                     logger.debug(`${matches.length} matches in '${file.path}'`);
                     const fh = new UpdatingFileHits(p, file, matches, content);
@@ -135,15 +135,15 @@ export function doWithFileMatches<M, P extends ProjectAsync = ProjectAsync>(p: P
  * Works regardless of the number of matches
  * @param p project
  * @param {string} globPatterns
- * @param {Microgrammar<M>} microgrammar
+ * @param {Grammar<M>} microgrammar
  * @param {(m: M) => void} action
  * @param {{makeUpdatable: boolean}} opts
  */
 export function doWithMatches<M, P extends ProjectAsync = ProjectAsync>(p: P,
-                                                                        globPatterns: GlobOptions,
-                                                                        microgrammar: Microgrammar<M>,
-                                                                        action: (m: M) => void,
-                                                                        opts: Opts = DefaultOpts): Promise<P> {
+    globPatterns: GlobOptions,
+    microgrammar: Grammar<M>,
+    action: (m: M) => void,
+    opts: Opts = DefaultOpts): Promise<P> {
     const fileAction = (fh: FileWithMatches<M>) => {
         fh.matches.forEach(action);
     };
@@ -155,15 +155,15 @@ export function doWithMatches<M, P extends ProjectAsync = ProjectAsync>(p: P,
  * Fail if zero or more than one.
  * @param p project
  * @param {string} globPatterns
- * @param {Microgrammar<M>} microgrammar
+ * @param {Grammar<M>} microgrammar
  * @param {(m: M) => void} action
  * @param {{makeUpdatable: boolean}} opts
  */
 export function doWithUniqueMatch<M, P extends ProjectAsync = ProjectAsync>(p: P,
-                                                                            globPatterns: GlobOptions,
-                                                                            microgrammar: Microgrammar<M>,
-                                                                            action: (m: M) => void,
-                                                                            opts: Opts = DefaultOpts): Promise<P> {
+    globPatterns: GlobOptions,
+    microgrammar: Grammar<M>,
+    action: (m: M) => void,
+    opts: Opts = DefaultOpts): Promise<P> {
     let count = 0;
     const guardedAction = (fh: FileWithMatches<M>) => {
         if (fh.matches.length !== 1) {
@@ -188,15 +188,15 @@ export function doWithUniqueMatch<M, P extends ProjectAsync = ProjectAsync>(p: P
  * Similar to doWithUniqueMatch, but accepts zero matches without error
  * @param p project
  * @param {string} globPatterns
- * @param {Microgrammar<M>} microgrammar
+ * @param {Grammar<M>} microgrammar
  * @param {(m: M) => void} action
  * @param {{makeUpdatable: boolean}} opts
  */
 export function doWithAtMostOneMatch<M, P extends ProjectAsync = ProjectAsync>(p: P,
-                                                                               globPatterns: GlobOptions,
-                                                                               microgrammar: Microgrammar<M>,
-                                                                               action: (m: M) => void,
-                                                                               opts: Opts = DefaultOpts): Promise<P> {
+    globPatterns: GlobOptions,
+    microgrammar: Grammar<M>,
+    action: (m: M) => void,
+    opts: Opts = DefaultOpts): Promise<P> {
     let count = 0;
     const guardedAction = (fh: FileWithMatches<M>) => {
         if (fh.matches.length !== 1) {
@@ -219,7 +219,7 @@ class UpdatingFileHits<M> implements FileWithMatches<M> {
     private updatable = false;
 
     constructor(private project: ProjectAsync, public readonly file: File,
-                public matches: Array<Match<M>>, public content: string) {
+        public matches: Array<Match<M>>, public content: string) {
     }
 
     public makeUpdatable() {

--- a/lib/tree/ast/matchTesters.ts
+++ b/lib/tree/ast/matchTesters.ts
@@ -1,13 +1,13 @@
-import { Microgrammar } from "@atomist/microgrammar";
+import { Grammar } from "@atomist/microgrammar";
 import { PatternMatch } from "@atomist/microgrammar/lib/PatternMatch";
 import { MatchTesterMaker } from "./astUtils";
 
 /**
  * Exclude matches that are within a match of the given microgrammar
- * @param {Microgrammar<any>} mg
+ * @param {Grammar<any>} mg
  * @return {MatchTesterMaker}
  */
-export function notWithin(mg: Microgrammar<any>): MatchTesterMaker {
+export function notWithin(mg: Grammar<any>): MatchTesterMaker {
     return async file => {
         const content = await file.getContent();
         const matches: PatternMatch[] = mg.findMatches(content);

--- a/lib/tree/ast/microgrammar/MicrogrammarBasedFileParser.ts
+++ b/lib/tree/ast/microgrammar/MicrogrammarBasedFileParser.ts
@@ -1,4 +1,4 @@
-import { Microgrammar } from "@atomist/microgrammar";
+import { Microgrammar, Grammar } from "@atomist/microgrammar";
 import {
     isTreePatternMatch,
     PatternMatch,
@@ -21,11 +21,11 @@ export class MicrogrammarBasedFileParser implements FileParser {
      * Create a new MicrogrammarBasedFileParser, around a single microgrammar
      * @param {string} rootName name of the root element
      * @param {string} matchName name of each match
-     * @param {Microgrammar<any>} grammar
+     * @param {Grammar<any>} grammar
      */
     constructor(public readonly rootName: string,
-                public readonly matchName: string,
-                public readonly grammar: Microgrammar<any>) {
+        public readonly matchName: string,
+        public readonly grammar: Grammar<any>) {
     }
 
     public async toAst(f: File): Promise<TreeNode> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,9 @@
       }
     },
     "@atomist/microgrammar": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.0.3.tgz",
-      "integrity": "sha512-XCtu0nnk5tiDMYsBv+hKNC3zbTIKY8mC4d634y4+XUX38FqXMm9TGSSWGeUL3/jL7uai09Gs3L9JfDUep3838A=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.0.4.tgz",
+      "integrity": "sha512-NBQc20oMOypEJNxRYDIPPV+VJg8GuX9AkJxdKwMWgeZSyYx3+0fumYnV/r9+fFlLacFG5zAIpgc/iw1F5Z66jQ=="
     },
     "@atomist/slack-messages": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {
-    "@atomist/microgrammar": "^1.0.3",
+    "@atomist/microgrammar": "^1.0.4",
     "@atomist/slack-messages": "1.1.0",
     "@atomist/tree-path": "1.0.2",
     "@octokit/rest": "^16.3.0",


### PR DESCRIPTION
This lets SDMs upgrade microgrammar, and still call parseUtils