### PR TITLE
Fix typo that crashed it

### DIFF
--- a/lib/internal/invoker/disposable.ts
+++ b/lib/internal/invoker/disposable.ts
@@ -23,7 +23,7 @@ export function dispose(ctx: HandlerContext): () => Promise<void> {
                                 logger.warn("Failed to release resource %s: %s", f2.what, error);
                             }))
                     , what: f1.what + " and " + f2.what,
-                }; x
+                };
             }
 
             const disposeEverything = (ctx as any).__disposables

--- a/lib/internal/invoker/disposable.ts
+++ b/lib/internal/invoker/disposable.ts
@@ -22,8 +22,8 @@ export function dispose(ctx: HandlerContext): () => Promise<void> {
                             .catch(error => {
                                 logger.warn("Failed to release resource %s: %s", f2.what, error);
                             }))
-                    , what: f1.what + " and " + f1.what,
-                };
+                    , what: f1.what + " and " + f2.what,
+                }; x
             }
 
             const disposeEverything = (ctx as any).__disposables


### PR DESCRIPTION
We combined the strings so much that a few projects ran into InvalidStringLength and crashed.

This is extra funny because it was building a string
"inconceivable and inconceivable and inconceivable  and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable and inconceivable..."