### PR TITLE
Export execPromise

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -247,6 +247,7 @@ export {
 } from "./lib/tree/ast/regex/RegexFileParser";
 export {
     WritableLog,
+    execPromise,
 } from "./lib/util/child_process";
 export * from "./lib/util/exec";
 export {


### PR DESCRIPTION
because execIn says to use this one instead, so it needs to be available