### PR TITLE
Suppress token when logging clone url

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -254,7 +254,22 @@ export {
     Issue,
     raiseIssue,
 } from "./lib/util/gitHub";
-export * from "./lib/util/logger";
+export {
+    addLogRedaction,
+    LoggingFormat,
+    LoggingConfiguration,
+    NoLogging,
+    PlainLogging,
+    MinimalLogging,
+    ClientLogging,
+    configureLogging,
+    clientLoggingConfiguration,
+    Logger,
+    LogMethod,
+    LeveledLogMethod,
+    LogCallback,
+    logger,
+} from "./lib/util/logger";
 export {
     doWithRetry,
     RetryOptions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3744,8 +3744,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -3766,14 +3765,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3788,20 +3785,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3918,8 +3912,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -3931,7 +3924,6 @@
           "version": "1.0.0",
           "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3946,7 +3938,6 @@
           "version": "3.0.4",
           "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3954,14 +3945,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3980,7 +3969,6 @@
           "version": "0.5.1",
           "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4061,8 +4049,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4074,7 +4061,6 @@
           "version": "1.4.0",
           "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4160,8 +4146,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4197,7 +4182,6 @@
           "version": "1.0.2",
           "resolved": "",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4217,7 +4201,6 @@
           "version": "3.0.1",
           "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4261,14 +4244,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },

--- a/test/util/logger.test.ts
+++ b/test/util/logger.test.ts
@@ -1,0 +1,84 @@
+import * as assert from "assert";
+import { TransformableInfo } from "logform";
+import {
+    addLogRedaction,
+    redact,
+} from "../../lib/util/logger";
+
+describe("redaction", () => {
+    it("redacts things", async () => {
+        const replacement = "[DO NOT LOOK]";
+
+        // sorry, but this will replace all booogers for the rest of the tests.
+        // That is why I spelled it oddly.
+        addLogRedaction(/booo+gers/, replacement);
+
+        const result = redact({
+            message: "booogers and carrots",
+        } as TransformableInfo);
+
+        assert(!result.message.includes("booogers"), "This should have been redacted");
+        assert(result.message.includes(replacement), "Don't look at me when I'm picking my nose");
+    });
+    it("if the regexp has groups, redact those and not the whole thing", async () => {
+
+        addLogRedaction(/(84 )tomprince( \w+ )t\w+( nal)/, "$1[RIP_TOM]$2[RIP_TOM]$3");
+
+        const result = redact({
+            message: "bujo84 tomprince malakai821 treguy nallaj",
+        } as TransformableInfo);
+
+        assert.strictEqual(result.message, "bujo84 [RIP_TOM] malakai821 [RIP_TOM] nallaj",
+            "The groups should have been redacted");
+    });
+    it("prints ordinary stuff", () => {
+        const originalMessage = "boogers and carrots";
+        const result = redact({
+            message: originalMessage,
+        } as TransformableInfo);
+
+        assert.strictEqual(result.message, originalMessage);
+    });
+
+    describe("hides github tokens after the file that might result in them being printed is loaded",
+        () => {
+            before(() => {
+                require("../../lib/operations/common/AbstractRemoteRepoRef.ts");
+            });
+
+            it("removes github token in username position", () => {
+
+                const result = redact({
+                    message: "https://12093847103847561098457012abfcdefab456ef:x-oauth-basic@blah blah blah blah",
+                } as TransformableInfo);
+
+                assert(!result.message.includes("12093847103847561098457012abfcdefab456ef"), "This should have been redacted");
+                assert(result.message.includes("https://[REDACTED_GITHUB_TOKEN]:x-oauth-basic@blah"),
+                    "Should be obvious about why it is changed");
+            });
+
+            // now let's try the other creds that get into cloneUrls
+
+            //  `${this.scheme}${encodeURIComponent(creds.username)}:${encodeURIComponent(creds.password)}@`
+            it("removes url auth password", () => {
+                const result = redact({
+                    message: "https://urlencoded%2Fusername:something%2Fpasswordy4785748@some.handy.website.com/things",
+                } as TransformableInfo);
+
+                assert(!result.message.includes("passwordy"), "This should have been redacted");
+                assert(result.message.includes("https://urlencoded%2Fusername:[REDACTED_URL_PASSWORD]@some"), "Be clear about why this is changed");
+            });
+
+            // `${this.scheme}gitlab-ci-token:${creds.privateToken}@`
+            it("removes gitlab ci token", () => {
+                const result = redact({
+                    message: "https://gitlab-ci-token:something-tokeny@blah blah blah blah",
+                } as TransformableInfo);
+
+                assert(!result.message.includes("something-tokeny"), "This should have been redacted");
+                assert(result.message.includes("https://gitlab-ci-token:[REDACTED_URL_PASSWORD]@blah"), "Be clear about why this is changed");
+            });
+
+        });
+
+});


### PR DESCRIPTION
So, while streaming, I noticed that my token was printing to the log when the SDM clones a repository. This is because the token gets sent on the command line, and we always print to the logs the commands that we run from exec/spawn. I like that we print those, but I don't want the tokens to show.

After some discussion with @johnsonr, I implemented a variant of what TeamCity does, which is to have some awareness of what passwords look like and redact them from the logs. In this case, the file that constructs the clone URL with tokens in it also asks the logger (globally) to suppress anything that looks like those tokens. This is a good idea.

This is not intended to be a complete solution of all password not-printing everywhere. It is general enough to cover the cases we know exist. This will be immediately useful in my stream, and will some others from my past fate of deleting my own tokens.