### PR TITLE
WebSocket can be destroyed before message sent

### DIFF
--- a/lib/internal/transport/websocket/WebSocketLifecycle.ts
+++ b/lib/internal/transport/websocket/WebSocketLifecycle.ts
@@ -1,5 +1,6 @@
 import * as TinyQueue from "tinyqueue";
 import * as WebSocket from "ws";
+import { logger } from "../../../util/logger";
 import { sendMessage } from "./WebSocketMessageClient";
 
 export interface WebSocketLifecycle {
@@ -82,7 +83,10 @@ export class QueuingWebSocketLifecycle implements WebSocketLifecycle {
      * @param msg
      */
     public send(msg: any): void {
-        if (this.connected()) {
+        if (!this) {
+            logger.warn(`WebSocket has been destroyed before we were able to send the message`);
+            return;
+        } else if (this.connected()) {
             sendMessage(msg, this.ws, true);
         } else {
             if (!this.timer) {

--- a/test/internal/transport/websocket/WebSocketMessageClient.test.ts
+++ b/test/internal/transport/websocket/WebSocketMessageClient.test.ts
@@ -44,19 +44,19 @@ describe("WebSocketMessageClient", () => {
                 data: {},
                 extensions: { team_id: "Txxxxxxx", correlation_id: corrId, operationName: "Foor" },
                 secrets: [],
-            }, new QueuingWebSocketLifecycle() );
+            }, new QueuingWebSocketLifecycle());
 
         const msg: SlackMessage = {
             attachments: [{
                 fallback: "test",
                 text: "test",
                 actions: [
-                    buttonForCommand({text: "Foo"}, "HelloWorld", {name: "cd"}),
+                    buttonForCommand({ text: "Foo" }, "HelloWorld", { name: "cd" }),
                 ],
             }],
         };
 
-        client.send(msg, { userAgent: "slack", team: "Txxxxxxx", users: ["cd", "rod"] } as SlackDestination, { id: "123456"})
+        client.send(msg, { userAgent: "slack", team: "Txxxxxxx", users: ["cd", "rod"] } as SlackDestination, { id: "123456" })
             .then(fm => {
                 assert(fm.api_version === "1");
                 assert(fm.correlation_id === corrId);
@@ -89,19 +89,19 @@ describe("WebSocketMessageClient", () => {
                 data: {},
                 extensions: { team_id: "Txxxxxxx", correlation_id: corrId, operationName: "Foor" },
                 secrets: [],
-            }, new QueuingWebSocketLifecycle() );
+            }, new QueuingWebSocketLifecycle());
 
         const msg: SlackMessage = {
             attachments: [{
                 fallback: "test",
                 text: "test",
                 actions: [
-                    buttonForCommand({text: "Foo"}, "HelloWorld", {name: "cd"}),
+                    buttonForCommand({ text: "Foo" }, "HelloWorld", { name: "cd" }),
                 ],
             }],
         };
 
-        client.send(msg, { userAgent: "slack", team: "Txxxxxxx", channels: ["general", "test"] } as SlackDestination, {id: "123456"})
+        client.send(msg, { userAgent: "slack", team: "Txxxxxxx", channels: ["general", "test"] } as SlackDestination, { id: "123456" })
             .then(fm => {
                 assert(fm.api_version === "1");
                 assert(fm.correlation_id === corrId);
@@ -152,19 +152,19 @@ describe("WebSocketMessageClient", () => {
                 parameters: [],
                 mapped_parameters: [],
                 secrets: [],
-            }, new QueuingWebSocketLifecycle() );
+            }, new QueuingWebSocketLifecycle());
 
         const msg: SlackMessage = {
             attachments: [{
                 fallback: "test",
                 text: "test",
                 actions: [
-                    buttonForCommand({text: "Foo"}, "HelloWorld", {name: "cd"}),
+                    buttonForCommand({ text: "Foo" }, "HelloWorld", { name: "cd" }),
                 ],
             }],
         };
 
-        client.respond(msg, {id: "123456"})
+        client.respond(msg, { id: "123456" })
             .then(fm => {
                 assert(fm.api_version === "1");
                 assert(fm.correlation_id === corrId);
@@ -213,7 +213,7 @@ describe("WebSocketMessageClient", () => {
                 parameters: [],
                 mapped_parameters: [],
                 secrets: [],
-            }, new QueuingWebSocketLifecycle() );
+            }, new QueuingWebSocketLifecycle());
 
         const msg: SlackFileMessage = {
             content: "some basic text",
@@ -223,7 +223,7 @@ describe("WebSocketMessageClient", () => {
             fileName: "some file",
         };
 
-        client.respond(msg, {id: "123456"})
+        client.respond(msg, { id: "123456" })
             .then(fm => {
                 assert(fm.api_version === "1");
                 assert(fm.correlation_id === corrId);

--- a/test/operations/support/editorUtils.test.ts
+++ b/test/operations/support/editorUtils.test.ts
@@ -24,7 +24,7 @@ describe("editorUtils", () => {
             { branch: "dont-create-me-or-i-barf&&&####&&& we", message: "whocares" });
         assert(!er.edited);
         await p.release();
-    });
+    }).timeout(5000);
 
     it("doesn't attempt to create PR without changes", async () => {
         const p = await GitCommandGitProject.cloned(Creds, RepoThatExists);
@@ -33,6 +33,6 @@ describe("editorUtils", () => {
         const er = await editProjectUsingPullRequest(undefined, p, NoOpEditor, new PullRequest("x", "y"));
         assert(!er.edited);
         await p.release();
-    });
+    }).timeout(5000);
 
 });


### PR DESCRIPTION
There were unhandled promise exceptions in the test because tests were
creating a websocket that never was connected and so was unable to
send messages.  The interval function kept running after the websocket
was destroyed, causing `this` to become undefined.  Since this could
also adversely affect normal operation, I added a check to ensure
`this` was defined.

Changes in the tests are whitespace and increasing the timeout on some
recently temperamental tests.
