### PR TITLE
Disable TSLint on generated types

### DIFF
--- a/bin/gql-gen.ts
+++ b/bin/gql-gen.ts
@@ -20,12 +20,12 @@ import * as util from "util";
  * @param cwd directory to use as base for location of lib dir
  * @return Resolved, full path to lib directory
  */
-function libDir(cwd: string): string {
+async function libDir(cwd: string): Promise<string> {
     const lib = path.resolve(cwd, "lib");
     const src = path.resolve(cwd, "src");
-    if (fs.existsSync(lib)) {
+    if (await fs.pathExists(lib)) {
         return lib;
-    } else if (fs.existsSync(src)) {
+    } else if (await fs.pathExists(src)) {
         return src;
     } else {
         return lib;
@@ -43,11 +43,8 @@ async function patchGraphQLCodeGenerator(cwd: string): Promise<void> {
         // patch up codegen template to create optional properties
         const codegenTemplate = path.join(cwd, "node_modules", "graphql-codegen-typescript-client", "dist", "index.js");
         if (await fs.pathExists(codegenTemplate)) {
-            let contents = (await fs.readFile(codegenTemplate)).toString();
-            contents = contents.replace(
-                /{{ name }}: {{ convertedFieldType/,
-                "{{ name }}?: {{ convertedFieldType");
-            await fs.writeFile(codegenTemplate, contents);
+            const contents = await fs.readFile(codegenTemplate, "utf8");
+            await fs.writeFile(codegenTemplate, contents.replace(/{{ name }}: {{ convertedFieldType/, "{{ name }}?: {{ convertedFieldType"));
         }
     } catch (e) {
         console.error(`Failed to patch graphql-code-generator: ${e.message}`);
@@ -61,15 +58,13 @@ async function patchGraphQLCodeGenerator(cwd: string): Promise<void> {
 async function main(): Promise<void> {
     try {
         const cwd = process.cwd();
-        const lib = libDir(cwd);
-
-        await patchGraphQLCodeGenerator(cwd);
+        const lib = await libDir(cwd);
 
         // check if the project has a custom schema
         const customSchemaLocation = path.join(lib, "graphql", "schema.json");
         const defaultSchemaLocation = path.join(cwd, "node_modules", "@atomist", "automation-client", "lib",
             "graph", "schema.json");
-        const schema = fs.existsSync(customSchemaLocation) ? customSchemaLocation : defaultSchemaLocation;
+        const schema = (await fs.pathExists(customSchemaLocation)) ? customSchemaLocation : defaultSchemaLocation;
 
         const gqlGenOutput = path.join(lib, "typings", "types.ts");
         await fs.ensureDir(path.dirname(gqlGenOutput));
@@ -78,6 +73,7 @@ async function main(): Promise<void> {
 
         const config: Types.Config = {
             overwrite: true,
+            watch: false,
             schema: [schema],
             generates: {
                 [gqlGenOutput]: {
@@ -97,16 +93,21 @@ async function main(): Promise<void> {
         const graphqlFiles = await util.promisify(glob)(graphQlGlob);
 
         if (graphqlFiles && graphqlFiles.length > 0) {
+            await patchGraphQLCodeGenerator(cwd);
             config.documents = [graphQlGlob];
             await generate(config);
+            const typesContent = await fs.readFile(gqlGenOutput, "utf8");
+            await fs.writeFile(gqlGenOutput, `/* tslint:disable */\n\n${typesContent}`, "utf8");
         } else {
-            console.info("No GraphQL files found in project. Skipping type generation...");
+            console.info("No GraphQL files found in project, skipping type generation.");
         }
+        process.exit(0);
 
     } catch (e) {
         console.error(`Generating GraphQL types failed: ${e.message}`);
         process.exit(1);
     }
+    throw new Error("Should never get here, process.exit() called above");
 }
 
 main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -5041,6 +5041,21 @@
         "valid-url": "1.0.9"
       },
       "dependencies": {
+        "graphql-codegen-core": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/graphql-codegen-core/-/graphql-codegen-core-0.16.1.tgz",
+          "integrity": "sha512-KtvZqvB6no+vPtkIYpYpVSCclT0zfqSVCDZXTYu4GiMV2RdI7C+2/WMhDGPXEj5xwb6jDWaYH23BqiN3kObtrw==",
+          "requires": {
+            "chalk": "2.4.2",
+            "change-case": "3.1.0",
+            "common-tags": "1.8.0",
+            "graphql-tag": "2.10.1",
+            "graphql-toolkit": "0.0.5",
+            "graphql-tools": "4.0.4",
+            "ts-log": "2.1.4",
+            "winston": "3.2.1"
+          }
+        },
         "is-glob": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
@@ -5081,6 +5096,23 @@
       "requires": {
         "graphql-codegen-core": "0.16.1",
         "import-from": "2.1.0"
+      },
+      "dependencies": {
+        "graphql-codegen-core": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/graphql-codegen-core/-/graphql-codegen-core-0.16.1.tgz",
+          "integrity": "sha512-KtvZqvB6no+vPtkIYpYpVSCclT0zfqSVCDZXTYu4GiMV2RdI7C+2/WMhDGPXEj5xwb6jDWaYH23BqiN3kObtrw==",
+          "requires": {
+            "chalk": "2.4.2",
+            "change-case": "3.1.0",
+            "common-tags": "1.8.0",
+            "graphql-tag": "2.10.1",
+            "graphql-toolkit": "0.0.5",
+            "graphql-tools": "4.0.4",
+            "ts-log": "2.1.4",
+            "winston": "3.2.1"
+          }
+        }
       }
     },
     "graphql-codegen-typescript-client": {
@@ -5091,6 +5123,23 @@
         "graphql-codegen-core": "0.16.1",
         "graphql-codegen-plugin-helpers": "0.16.1",
         "graphql-codegen-typescript-common": "0.16.1"
+      },
+      "dependencies": {
+        "graphql-codegen-core": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/graphql-codegen-core/-/graphql-codegen-core-0.16.1.tgz",
+          "integrity": "sha512-KtvZqvB6no+vPtkIYpYpVSCclT0zfqSVCDZXTYu4GiMV2RdI7C+2/WMhDGPXEj5xwb6jDWaYH23BqiN3kObtrw==",
+          "requires": {
+            "chalk": "2.4.2",
+            "change-case": "3.1.0",
+            "common-tags": "1.8.0",
+            "graphql-tag": "2.10.1",
+            "graphql-toolkit": "0.0.5",
+            "graphql-tools": "4.0.4",
+            "ts-log": "2.1.4",
+            "winston": "3.2.1"
+          }
+        }
       }
     },
     "graphql-codegen-typescript-common": {
@@ -5102,6 +5151,23 @@
         "common-tags": "1.8.0",
         "graphql-codegen-core": "0.16.1",
         "graphql-codegen-plugin-helpers": "0.16.1"
+      },
+      "dependencies": {
+        "graphql-codegen-core": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/graphql-codegen-core/-/graphql-codegen-core-0.16.1.tgz",
+          "integrity": "sha512-KtvZqvB6no+vPtkIYpYpVSCclT0zfqSVCDZXTYu4GiMV2RdI7C+2/WMhDGPXEj5xwb6jDWaYH23BqiN3kObtrw==",
+          "requires": {
+            "chalk": "2.4.2",
+            "change-case": "3.1.0",
+            "common-tags": "1.8.0",
+            "graphql-tag": "2.10.1",
+            "graphql-toolkit": "0.0.5",
+            "graphql-tools": "4.0.4",
+            "ts-log": "2.1.4",
+            "winston": "3.2.1"
+          }
+        }
       }
     },
     "graphql-codegen-typescript-server": {


### PR DESCRIPTION
Add tslint:disable comment to top of generated types file.  Make
things more async.  Only patch GraphQL TypeScript template if
generating types.

Closes #481