### PR TITLE
Create single interface for creating RemoteRepoRef

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -97,6 +97,9 @@ export {
     OnEvent,
 } from "./lib/onEvent";
 export {
+    BitBucketRepoRef,
+} from "./lib/operations/common/BitBucketRepoRef";
+export {
     BitBucketServerRepoRef,
 } from "./lib/operations/common/BitBucketServerRepoRef";
 export {
@@ -114,6 +117,11 @@ export {
     TokenCredentials,
 } from "./lib/operations/common/ProjectOperationCredentials";
 export {
+    remoteRepoRefFrom,
+    RemoteRepoRefFromParams,
+} from "./lib/operations/common/remoteRepoRef";
+export {
+    ProviderType as ScmProviderType,
     RemoteRepoRef,
     RepoId,
     RepoRef,

--- a/lib/internal/transport/cluster/ClusterMasterRequestProcessor.ts
+++ b/lib/internal/transport/cluster/ClusterMasterRequestProcessor.ts
@@ -45,7 +45,11 @@ import {
     WorkerMessage,
 } from "./messages";
 
-type MessageType = { message: MasterMessage, dispatched: Dispatched<any>, ts: number };
+interface MessageType {
+    message: MasterMessage;
+    dispatched: Dispatched<any>;
+    ts: number;
+}
 
 /**
  * A RequestProcessor that delegates to Node.JS Cluster workers to do the actual
@@ -322,7 +326,7 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
         }
 
         const deadEvents = [];
-        this.events.forEach((e,k) => {
+        this.events.forEach((e, k) => {
             const worker = workers.find(w => w.worker.id === e.worker);
             if (!!worker) {
                 worker.messages = worker.messages + 1;
@@ -398,22 +402,19 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
                     this.messages.length,
                     1,
                     [],
-                    () => {
-                    });
+                    () => { /* intentionally empty */ });
                 statsd.gauge(
                     "work_queue.events",
                     this.events.size,
                     1,
                     [],
-                    () => {
-                    });
+                    () => { /* intentionally empty */ });
                 statsd.gauge(
                     "work_queue.commands",
                     this.commands.size,
                     1,
                     [],
-                    () => {
-                    });
+                    () => { /* intentionally empty */ });
             }
         }
     }

--- a/lib/internal/transport/websocket/WebSocketLifecycle.ts
+++ b/lib/internal/transport/websocket/WebSocketLifecycle.ts
@@ -1,4 +1,4 @@
-import * as TinyQueue from "tinyqueue"
+import * as TinyQueue from "tinyqueue";
 import * as WebSocket from "ws";
 import { logger } from "../../../util/logger";
 import { sendMessage } from "./WebSocketMessageClient";

--- a/lib/operations/common/BitBucketRepoRef.ts
+++ b/lib/operations/common/BitBucketRepoRef.ts
@@ -28,9 +28,9 @@ export class BitBucketRepoRef extends AbstractRemoteRepoRef {
                 sha?: string,
                 public apiBase = BitBucketDotComBase,
                 path?: string,
-                branch?: string) {
-        super(ProviderType.bitbucket_cloud, "https://bitbucket.org", apiBase, owner, repo, sha, path);
-        this.branch = branch;
+                branch?: string,
+                remote?: string) {
+        super(ProviderType.bitbucket_cloud, remote || "https://bitbucket.org", apiBase, owner, repo, sha, path, branch);
     }
 
     public createRemote(creds: ProjectOperationCredentials, description: string, visibility): Promise<ActionResult<this>> {

--- a/lib/operations/common/BitBucketServerRepoRef.ts
+++ b/lib/operations/common/BitBucketServerRepoRef.ts
@@ -40,9 +40,9 @@ export class BitBucketServerRepoRef extends AbstractRemoteRepoRef {
                 private readonly isProject: boolean = true,
                 sha?: string,
                 path?: string,
-                branch?: string) {
-        super(ProviderType.bitbucket, remoteBase, noTrailingSlash(remoteBase) + "/rest/api/1.0/", owner, repo, sha, path);
-        this.branch = branch;
+                branch?: string,
+                apiUrl?: string) {
+        super(ProviderType.bitbucket, remoteBase, apiUrl || `${noTrailingSlash(remoteBase)}/rest/api/1.0/`, owner, repo, sha, path, branch);
         this.ownerType = isProject ? "projects" : "users";
         logger.info("Constructed BitBucketServerRepoRef: %j", this);
     }
@@ -151,11 +151,7 @@ export class BitBucketServerRepoRef extends AbstractRemoteRepoRef {
     }
 
     get url() {
-        let url: string = `projects/${this.owner}/repos`;
-        if (!this.isProject) {
-            url = `users/${this.owner}/repos`;
-        }
-        return `${this.scheme}${this.remoteBase}/${url}/${this.repo}`;
+        return `${this.scheme}${this.remoteBase}/${this.ownerType}/${this.owner}/repos/${this.repo}`;
     }
 
     get pathComponent(): string {

--- a/lib/operations/common/GitHubRepoRef.ts
+++ b/lib/operations/common/GitHubRepoRef.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,8 +46,7 @@ export class GitHubRepoRef extends AbstractRemoteRepoRef {
         if (params.sha && !params.sha.match(GitShaRegExp.pattern)) {
             throw new Error("You provided an invalid SHA: " + params.sha);
         }
-        const result = new GitHubRepoRef(params.owner, params.repo, params.sha, params.rawApiBase, params.path);
-        result.branch = params.branch;
+        const result = new GitHubRepoRef(params.owner, params.repo, params.sha, params.rawApiBase, params.path, params.branch);
         return result;
     }
 
@@ -55,14 +54,9 @@ export class GitHubRepoRef extends AbstractRemoteRepoRef {
 
     public readonly apiBase: string;
 
-    constructor(owner: string,
-                repo: string,
-                sha?: string,
-                rawApiBase = GitHubDotComBase,
-                path?: string) {
-        super(
-            rawApiBase === GitHubDotComBase || rawApiBase === FullGitHubDotComBase ? ProviderType.github_com : ProviderType.ghe,
-            apiBaseToRemoteBase(rawApiBase), rawApiBase, owner, repo, sha, path);
+    constructor(owner: string, repo: string, sha?: string, rawApiBase = GitHubDotComBase, path?: string, branch?: string, remoteBase?: string) {
+        super(rawApiBase === GitHubDotComBase || rawApiBase === FullGitHubDotComBase ? ProviderType.github_com : ProviderType.ghe,
+            remoteBase || apiBaseToRemoteBase(rawApiBase), rawApiBase, owner, repo, sha, path, branch);
     }
 
     public createRemote(creds: ProjectOperationCredentials, description: string, visibility: string): Promise<ActionResult<this>> {

--- a/lib/operations/common/GitlabRepoRef.ts
+++ b/lib/operations/common/GitlabRepoRef.ts
@@ -34,8 +34,8 @@ export class GitlabRepoRef extends AbstractRemoteRepoRef {
         if (params.sha && !params.sha.match(GitShaRegExp.pattern)) {
             throw new Error("You provided an invalid SHA: " + params.sha);
         }
-        const result = new GitlabRepoRef(params.owner, params.repo, params.sha, params.rawApiBase, params.gitlabRemoteUrl, params.path);
-        result.branch = params.branch;
+        const result = new GitlabRepoRef(params.owner, params.repo, params.sha, params.rawApiBase, params.gitlabRemoteUrl, params.path,
+            params.branch);
         return result;
     }
 
@@ -62,14 +62,10 @@ export class GitlabRepoRef extends AbstractRemoteRepoRef {
                         sha: string,
                         public apiBase = GitlabDotComApiBase,
                         gitlabRemoteUrl: string = GitlabDotComRemoteUrl,
-                        path?: string) {
+                        path?: string,
+                        branch?: string) {
         super(apiBase === GitlabDotComApiBase ? ProviderType.gitlab_com : ProviderType.gitlab_enterprise,
-            gitlabRemoteUrl,
-            apiBase,
-            owner,
-            repo,
-            sha,
-            path);
+            gitlabRemoteUrl, apiBase, owner, repo, sha, path, branch);
     }
 
     public async createRemote(creds: ProjectOperationCredentials, description: string, visibility): Promise<ActionResult<this>> {
@@ -95,10 +91,10 @@ export class GitlabRepoRef extends AbstractRemoteRepoRef {
                 response,
             };
         }).catch(err => {
-                logger.error(`Error attempting to create remote project, status code ${err.response.status}. ` +
-                    `The response was ${JSON.stringify(err.response.data)}`);
-                return Promise.reject(err);
-            });
+            logger.error(`Error attempting to create remote project, status code ${err.response.status}. ` +
+                `The response was ${JSON.stringify(err.response.data)}`);
+            return Promise.reject(err);
+        });
     }
 
     public deleteRemote(creds: ProjectOperationCredentials): Promise<ActionResult<this>> {
@@ -118,9 +114,9 @@ export class GitlabRepoRef extends AbstractRemoteRepoRef {
                 response,
             };
         }).catch(err => {
-                logger.error("Error attempting to delete repository: " + err);
-                return Promise.reject(err);
-            });
+            logger.error("Error attempting to delete repository: " + err);
+            return Promise.reject(err);
+        });
     }
 
     public setUserConfig(credentials: ProjectOperationCredentials, project: Configurable): Promise<ActionResult<any>> {
@@ -152,10 +148,10 @@ export class GitlabRepoRef extends AbstractRemoteRepoRef {
                 response,
             };
         }).catch(err => {
-                logger.error(`Error attempting to raise PR, status code ${err.response.status}. ` +
-                    `The response was ${JSON.stringify(err.response.data)}`);
-                return Promise.reject(err);
-            });
+            logger.error(`Error attempting to raise PR, status code ${err.response.status}. ` +
+                `The response was ${JSON.stringify(err.response.data)}`);
+            return Promise.reject(err);
+        });
     }
 
     private getNamespaceForOwner(owner: string, creds: ProjectOperationCredentials): Promise<number> {

--- a/lib/operations/common/RepoId.ts
+++ b/lib/operations/common/RepoId.ts
@@ -1,4 +1,3 @@
-
 import { ActionResult } from "../../action/ActionResult";
 import { Configurable } from "../../project/git/Configurable";
 import { ProjectOperationCredentials } from "./ProjectOperationCredentials";
@@ -50,12 +49,21 @@ export interface RepoRef extends RepoId {
 
 }
 
+/**
+ * Supported SCM providers.
+ */
 export enum ProviderType {
-    bitbucket_cloud,
-    github_com,
-    ghe,
+    /** BitBucket server instances, maps to [[BitBucketServerRepoRef]] */
     bitbucket,
+    /** Atlassian-hosted BitBucket cloud, maps to [[BitBucketRepoRef]] */
+    bitbucket_cloud,
+    /** GitHub.com, maps to [[GitHubRepoRef]] */
+    github_com,
+    /** GitHub Enterprise, maps to [[GitHubRepoRef]] */
+    ghe,
+    /** Gitlab.com, maps to [[GitlabRepoRef]] */
     gitlab_com,
+    /** Gitlab Enterprise, maps to [[GitlabRepoRef]] */
     gitlab_enterprise,
 }
 
@@ -66,12 +74,11 @@ export enum ProviderType {
  */
 export interface RemoteRepoRef extends RepoRef {
 
+    /** @deprecated use providerType */
     readonly kind: string;
-    /**
-     * Remote base
-     */
+    /** Base root remote clone */
     readonly remoteBase: string;
-
+    /** SCM provider of remote repo */
     readonly providerType: ProviderType;
 
     /**

--- a/lib/operations/common/remoteRepoRef.ts
+++ b/lib/operations/common/remoteRepoRef.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { BitBucketRepoRef } from "./BitBucketRepoRef";
+import { BitBucketServerRepoRef } from "./BitBucketServerRepoRef";
+import { GitHubRepoRef } from "./GitHubRepoRef";
+import { GitlabRepoRef } from "./GitlabRepoRef";
+import {
+    ProviderType,
+    RemoteRepoRef,
+} from "./RepoId";
+
+/**
+ * Generic set of parameters to create a RemoteRepoRef.
+ */
+export interface RemoteRepoRefFromParams {
+    /** Repository owner, i.e., user or organization */
+    owner: string;
+    /** SCM provider */
+    providerType: ProviderType;
+    /** Repository name */
+    repo: string;
+
+    /** SCM provider root API URL */
+    apiUrl?: string;
+    /** Branch to check out, if not specified default branch is checked out */
+    branch?: string;
+    /** Path within repository to checkout */
+    path?: string;
+    /** SCM provider root remote cloning URL */
+    remoteUrl?: string;
+    /** Git SHA to checkout, if omitted the HEAD of the branch is checked out */
+    sha?: string;
+
+    /**
+     * Is the repository under a BitBucket Server project?  This
+     * property is ignored for all other SCM providers.
+     */
+    isProject?: boolean;
+}
+
+/**
+ * Create the appropriate remote repo ref given the params.
+ *
+ * @param params properties of remote repo ref
+ * @return appropriate remote repo ref object
+ */
+export function remoteRepoRefFrom(id: RemoteRepoRefFromParams): RemoteRepoRef {
+    switch (id.providerType) {
+        case ProviderType.bitbucket_cloud:
+            return new BitBucketRepoRef(id.owner, id.repo, id.sha, id.apiUrl, id.path, id.branch, id.remoteUrl);
+        // tslint:disable-next-line:deprecation
+        case ProviderType.bitbucket:
+            return new BitBucketServerRepoRef(id.remoteUrl, id.owner, id.repo, id.isProject, id.sha, id.path, id.branch, id.apiUrl);
+        case ProviderType.github_com:
+        case ProviderType.ghe:
+            return new GitHubRepoRef(id.owner, id.repo, id.sha, id.apiUrl, id.path, id.branch, id.remoteUrl);
+        case ProviderType.gitlab_com:
+        case ProviderType.gitlab_enterprise:
+            return GitlabRepoRef.from({ ...id, rawApiBase: id.apiUrl, gitlabRemoteUrl: id.remoteUrl });
+        default:
+            throw new Error(`SCM provider type '${id.providerType}' did not match any known provider`);
+    }
+}

--- a/test/util/logger.test.ts
+++ b/test/util/logger.test.ts
@@ -1,84 +1,97 @@
-import * as assert from "assert";
 import { TransformableInfo } from "logform";
+import * as assert from "power-assert";
 import {
     addLogRedaction,
     redact,
 } from "../../lib/util/logger";
 
-describe("redaction", () => {
-    it("redacts things", async () => {
-        const replacement = "[DO NOT LOOK]";
+// require for its addLogRedaction calls
+// tslint:disable-next-line:no-var-requires
+require("../../lib/operations/common/AbstractRemoteRepoRef.ts");
 
-        // sorry, but this will replace all booogers for the rest of the tests.
-        // That is why I spelled it oddly.
-        addLogRedaction(/booo+gers/, replacement);
+describe("util/logger", () => {
 
-        const result = redact({
-            message: "booogers and carrots",
-        } as TransformableInfo);
+    describe("redaction", () => {
 
-        assert(!result.message.includes("booogers"), "This should have been redacted");
-        assert(result.message.includes(replacement), "Don't look at me when I'm picking my nose");
-    });
-    it("if the regexp has groups, redact those and not the whole thing", async () => {
+        it("redacts things", async () => {
+            const replacement = "[DO NOT LOOK]";
 
-        addLogRedaction(/(84 )tomprince( \w+ )t\w+( nal)/, "$1[RIP_TOM]$2[RIP_TOM]$3");
+            // sorry, but this will replace all booogers for the rest of the tests.
+            // That is why I spelled it oddly.
+            addLogRedaction(/booo+gers/, replacement);
 
-        const result = redact({
-            message: "bujo84 tomprince malakai821 treguy nallaj",
-        } as TransformableInfo);
+            const result = redact({
+                message: "booogers and carrots",
+            } as TransformableInfo);
 
-        assert.strictEqual(result.message, "bujo84 [RIP_TOM] malakai821 [RIP_TOM] nallaj",
-            "The groups should have been redacted");
-    });
-    it("prints ordinary stuff", () => {
-        const originalMessage = "boogers and carrots";
-        const result = redact({
-            message: originalMessage,
-        } as TransformableInfo);
-
-        assert.strictEqual(result.message, originalMessage);
-    });
-
-    describe("hides github tokens after the file that might result in them being printed is loaded",
-        () => {
-            before(() => {
-                require("../../lib/operations/common/AbstractRemoteRepoRef.ts");
-            });
-
-            it("removes github token in username position", () => {
-
-                const result = redact({
-                    message: "https://12093847103847561098457012abfcdefab456ef:x-oauth-basic@blah blah blah blah",
-                } as TransformableInfo);
-
-                assert(!result.message.includes("12093847103847561098457012abfcdefab456ef"), "This should have been redacted");
-                assert(result.message.includes("https://[REDACTED_GITHUB_TOKEN]:x-oauth-basic@blah"),
-                    "Should be obvious about why it is changed");
-            });
-
-            // now let's try the other creds that get into cloneUrls
-
-            //  `${this.scheme}${encodeURIComponent(creds.username)}:${encodeURIComponent(creds.password)}@`
-            it("removes url auth password", () => {
-                const result = redact({
-                    message: "https://urlencoded%2Fusername:something%2Fpasswordy4785748@some.handy.website.com/things",
-                } as TransformableInfo);
-
-                assert(!result.message.includes("passwordy"), "This should have been redacted");
-                assert(result.message.includes("https://urlencoded%2Fusername:[REDACTED_URL_PASSWORD]@some"), "Be clear about why this is changed");
-            });
-
-            // `${this.scheme}gitlab-ci-token:${creds.privateToken}@`
-            it("removes gitlab ci token", () => {
-                const result = redact({
-                    message: "https://gitlab-ci-token:something-tokeny@blah blah blah blah",
-                } as TransformableInfo);
-
-                assert(!result.message.includes("something-tokeny"), "This should have been redacted");
-                assert(result.message.includes("https://gitlab-ci-token:[REDACTED_URL_PASSWORD]@blah"), "Be clear about why this is changed");
-            });
-
+            assert(!result.message.includes("booogers"), "This should have been redacted");
+            assert(result.message.includes(replacement), "Don't look at me when I'm picking my nose");
         });
+
+        it("if the regexp has groups, redact those and not the whole thing", async () => {
+
+            addLogRedaction(/(84 )tomprince( \w+ )t\w+( nal)/, "$1[RIP_TOM]$2[RIP_TOM]$3");
+
+            const result = redact({
+                message: "bujo84 tomprince malakai821 treguy nallaj",
+            } as TransformableInfo);
+
+            assert.strictEqual(result.message, "bujo84 [RIP_TOM] malakai821 [RIP_TOM] nallaj",
+                "The groups should have been redacted");
+        });
+
+        it("prints ordinary stuff", () => {
+            const originalMessage = "boogers and carrots";
+            const result = redact({
+                message: originalMessage,
+            } as TransformableInfo);
+
+            assert.strictEqual(result.message, originalMessage);
+        });
+
+        it("removes github token in username position", () => {
+
+            const result = redact({
+                message: "https://12093847103847561098457012abfcdefab456ef:x-oauth-basic@blah blah blah blah",
+            } as TransformableInfo);
+
+            assert(!result.message.includes("12093847103847561098457012abfcdefab456ef"), "This should have been redacted");
+            assert(result.message.includes("https://[REDACTED_GITHUB_TOKEN]:x-oauth-basic@blah"),
+                "Should be obvious about why it is changed");
+        });
+
+        it("removes github token with x-oauth-basic", () => {
+
+            const result = redact({
+                message: "https://12093847103847561098457012abfcdefab456ef@blah blah blah blah",
+            } as TransformableInfo);
+
+            assert(!result.message.includes("12093847103847561098457012abfcdefab456ef"), "This should have been redacted");
+            assert(result.message.includes("https://[REDACTED_GITHUB_TOKEN]@blah"), "bare token not removed");
+        });
+
+        // now let's try the other creds that get into cloneUrls
+
+        //  `${this.scheme}${encodeURIComponent(creds.username)}:${encodeURIComponent(creds.password)}@`
+        it("removes url auth password", () => {
+            const result = redact({
+                message: "https://urlencoded%2Fusername:something%2Fpasswordy4785748@some.handy.website.com/things",
+            } as TransformableInfo);
+
+            assert(!result.message.includes("passwordy"), "This should have been redacted");
+            assert(result.message.includes("https://urlencoded%2Fusername:[REDACTED_URL_PASSWORD]@some"), "Be clear about why this is changed");
+        });
+
+        // `${this.scheme}gitlab-ci-token:${creds.privateToken}@`
+        it("removes gitlab ci token", () => {
+            const result = redact({
+                message: "https://gitlab-ci-token:something-tokeny@blah blah blah blah",
+            } as TransformableInfo);
+
+            assert(!result.message.includes("something-tokeny"), "This should have been redacted");
+            assert(result.message.includes("https://gitlab-ci-token:[REDACTED_URL_PASSWORD]@blah"), "Be clear about why this is changed");
+        });
+
+    });
 
 });


### PR DESCRIPTION
Each RemoteRemoteRef implementation has slightly different ways they
are created.  Add a single function with an object parameter to unify
creation of the various RemoteRepoRefs.

Export the new function and the missing BitBucketRepoRef and
ProviderType as ScmProviderType from the index.

Delint and fix token redacting and some tests.