### PR TITLE
Redact outgoing messages

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,6 +27,7 @@ export {
     Configuration,
     ConfigurationPostProcessor,
     configurationValue,
+    DEFAULT_REDACTION_PATTERNS,
 } from "./lib/configuration";
 export {
     MappedParameter,
@@ -259,7 +260,6 @@ export {
     raiseIssue,
 } from "./lib/util/gitHub";
 export {
-    addLogRedaction,
     LoggingFormat,
     LoggingConfiguration,
     NoLogging,
@@ -274,6 +274,10 @@ export {
     LogCallback,
     logger,
 } from "./lib/util/logger";
+export {
+    addRedaction,
+    addLogRedaction,
+} from "./lib/util/redact"
 export {
     doWithRetry,
     RetryOptions,

--- a/lib/configuration.ts
+++ b/lib/configuration.ts
@@ -258,6 +258,15 @@ export interface AutomationServerOptions extends AutomationOptions {
             level?: "silly" | "debug" | "verbose" | "info" | "warn" | "error";
         };
     };
+    /** Redaction configuration */
+    redact?: {
+        /** Redact log messages */
+        log?: boolean;
+        /** Redact messages send via the message client */
+        messages?: boolean;
+        /** Register patterns to look for and optional replacements */
+        patterns?: Array<{ regexp: RegExp | string, replacement?: string }>;
+    };
     /** statsd config */
     statsd?: {
         /** Whether to send metrics statsd, default is false */
@@ -941,6 +950,17 @@ export function loadConfiguration(cfgPath?: string): Promise<Configuration> {
         });
 }
 
+export const DEFAULT_REDACTION_PATTERNS = [
+    {
+        regexp: /[0-9a-f]{40}((?::x-oauth-basic)?@)/g,
+        replacement: "[REDACTED_GITHUB_TOKEN]$1",
+    },
+    {
+        regexp: /(https?:\/\/[^:\/\?#\[\]@]+:)[^:\/\?#\[\]@]+(@)/g,
+        replacement: "$1[REDACTED_URL_PASSWORD]$2",
+    },
+];
+
 /**
  * Default configuration when running in neither testing or
  * production.
@@ -1008,6 +1028,11 @@ export const LocalDefaultConfiguration: Configuration = {
     },
     statsd: {
         enabled: false,
+    },
+    redact: {
+        log: true,
+        messages: true,
+        patterns: DEFAULT_REDACTION_PATTERNS,
     },
     commands: null,
     events: null,

--- a/lib/internal/transport/cluster/ClusterMasterRequestProcessor.ts
+++ b/lib/internal/transport/cluster/ClusterMasterRequestProcessor.ts
@@ -367,9 +367,9 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
 
     protected createMessageClient(event: CommandIncoming | EventIncoming): MessageClient {
         if (isCommandIncoming(event)) {
-            return new WebSocketCommandMessageClient(event, this.webSocketLifecycle);
+            return new WebSocketCommandMessageClient(event, this.webSocketLifecycle, this.configuration);
         } else if (isEventIncoming(event)) {
-            return new WebSocketEventMessageClient(event, this.webSocketLifecycle);
+            return new WebSocketEventMessageClient(event, this.webSocketLifecycle, this.configuration);
         }
     }
 

--- a/lib/internal/transport/express/ExpressRequestProcessor.ts
+++ b/lib/internal/transport/express/ExpressRequestProcessor.ts
@@ -61,7 +61,7 @@ export class ExpressRequestProcessor extends AbstractRequestProcessor {
                                   context: AutomationContextAware): MessageClient {
         return !!this.configuration.http.messageClientFactory ?
             this.configuration.http.messageClientFactory(context) :
-            new ExpressMessageClient(event);
+            new ExpressMessageClient(event, this.configuration);
     }
 }
 
@@ -69,14 +69,14 @@ class ExpressMessageClient implements MessageClient {
 
     private delegate: MessageClient;
 
-    constructor(private event: EventIncoming | CommandIncoming) {
+    constructor(private event: EventIncoming | CommandIncoming, configuration: Configuration) {
         if (automationClientInstance().webSocketHandler
             && (automationClientInstance().webSocketHandler as any).webSocketLifecycle) {
             const ws = (automationClientInstance().webSocketHandler as any).webSocketLifecycle as WebSocketLifecycle;
             if (isCommandIncoming(this.event)) {
-                this.delegate = new WebSocketCommandMessageClient(this.event, ws);
+                this.delegate = new WebSocketCommandMessageClient(this.event, ws, configuration);
             } else if (isEventIncoming(this.event)) {
-                this.delegate = new WebSocketEventMessageClient(this.event, ws);
+                this.delegate = new WebSocketEventMessageClient(this.event, ws, configuration);
             }
         }
     }

--- a/lib/internal/transport/websocket/DefaultWebSocketRequestProcessor.ts
+++ b/lib/internal/transport/websocket/DefaultWebSocketRequestProcessor.ts
@@ -88,9 +88,9 @@ export class DefaultWebSocketRequestProcessor extends AbstractRequestProcessor
 
     protected createMessageClient(event: CommandIncoming | EventIncoming): MessageClient {
         if (isCommandIncoming(event)) {
-            return new WebSocketCommandMessageClient(event, this.webSocketLifecycle);
+            return new WebSocketCommandMessageClient(event, this.webSocketLifecycle, this.configuration);
         } else if (isEventIncoming(event)) {
-            return new WebSocketEventMessageClient(event, this.webSocketLifecycle);
+            return new WebSocketEventMessageClient(event, this.webSocketLifecycle, this.configuration);
         }
     }
 }

--- a/lib/operations/common/AbstractRemoteRepoRef.ts
+++ b/lib/operations/common/AbstractRemoteRepoRef.ts
@@ -17,7 +17,6 @@
 
 import { ActionResult } from "../../action/ActionResult";
 import { Configurable } from "../../project/git/Configurable";
-import { addLogRedaction } from "../../util/logger";
 import { isBasicAuthCredentials } from "./BasicAuthCredentials";
 import { isGitlabPrivateTokenCredentials } from "./GitlabPrivateTokenCredentials";
 import {
@@ -28,10 +27,6 @@ import {
     ProviderType,
     RemoteRepoRef,
 } from "./RepoId";
-
-addLogRedaction(/[0-9a-f]{40}((?::x-oauth-basic)?@)/g, "[REDACTED_GITHUB_TOKEN]$1");
-// ordering matters: keep this after the Github token one, which happens to look at the password, and this replacement would make it not match
-addLogRedaction(/(https?:\/\/[^:\/\?#\[\]@]+:)[^:\/\?#\[\]@]+(@)/g, "$1[REDACTED_URL_PASSWORD]$2");
 
 /**
  * Superclass for RemoteRepoRef implementations.

--- a/lib/util/redact.ts
+++ b/lib/util/redact.ts
@@ -1,0 +1,37 @@
+import * as logform from "logform";
+
+const redactions: Array<{ redacted: RegExp, replacement: string }> = [];
+
+/**
+ * Prepare the logging to exclude something.
+ * If you know you're about to, say, spawn a process that will get printed
+ * to the log and will reveal something secret, then prepare the logger to
+ * exclude that secret thing.
+ *
+ * Pass a regular expression that will match the secret thing and very little else.
+ */
+export function addRedaction(redacted: RegExp, suggestedReplacement?: string) {
+    const replacement = suggestedReplacement || "[REDACTED]";
+    redactions.push({ redacted, replacement });
+}
+
+/**
+ * @deprecated use addRedaction
+ */
+export const addLogRedaction = addRedaction;
+
+export function redact(message: string): string {
+    let output = message;
+    redactions.forEach(r => {
+        output = typeof output === "string" ? output.replace(r.redacted, r.replacement) : output;
+    });
+    return output;
+}
+
+export function redactLog(logInfo: logform.TransformableInfo): logform.TransformableInfo {
+    let output = logInfo.message;
+    redactions.forEach(r => {
+        output = typeof output === "string" ? output.replace(r.redacted, r.replacement) : output;
+    });
+    return { ...logInfo, message: output };
+}

--- a/test/command/HelloWorld.ts
+++ b/test/command/HelloWorld.ts
@@ -17,10 +17,10 @@ import {
 import {
     addressEvent,
     addressSlackChannels,
-    addressSlackChannelsFromContext,
     addressSlackUsers,
     addressSlackUsersFromContext,
 } from "../../lib/spi/message/MessageClient";
+import { logger } from "../../lib/util/logger";
 import { SecretBaseHandler } from "./SecretBaseHandler";
 
 @ConfigurableCommandHandler("Send a hello back to the client", { intent: "hello cd", autoSubmit: true })
@@ -45,7 +45,10 @@ export class HelloWorld extends SecretBaseHandler implements HandleCommand {
             },
         };
 
-        await ctx.messageClient.send({ text: "test"}, await addressSlackUsersFromContext(ctx, "cd"));
+
+        logger.info(" hello look bla bla https://test:superpassword@google.com test");
+
+        await ctx.messageClient.send({ text: "https://test:superpassword@google.com"}, await addressSlackUsersFromContext(ctx, "cd"), { thread: true });
 
         await ctx.messageClient.send({ text: "test" }, addressSlackChannels(ctx.workspaceId, "handlers"));
         await ctx.messageClient.send({ text: "test" }, addressSlackUsers(ctx.workspaceId, "cd"), { id: null });

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -11,6 +11,7 @@ import {
     AutomationServerOptions,
     Configuration,
     configurationValue,
+    DEFAULT_REDACTION_PATTERNS,
     defaultConfiguration,
     loadAtomistConfig,
     loadAtomistConfigPath,
@@ -109,6 +110,11 @@ describe("configuration", () => {
                 enabled: true,
                 contributors: [],
             },
+        },
+        redact: {
+            log: true,
+            messages: true,
+            patterns: DEFAULT_REDACTION_PATTERNS,
         },
         statsd: {
             enabled: false,

--- a/test/internal/transport/websocket/WebSocketMessageClient.test.ts
+++ b/test/internal/transport/websocket/WebSocketMessageClient.test.ts
@@ -22,7 +22,7 @@ describe("WebSocketMessageClient", () => {
                 data: {},
                 extensions: { team_id: "Txxxxxxx", correlation_id: guid(), operationName: "Foor" },
                 secrets: [],
-            }, null);
+            }, null, {});
         client.respond("Some test message")
             .catch(err => {
                 assert(err.message === "Response messages are not supported for event handlers");
@@ -44,7 +44,7 @@ describe("WebSocketMessageClient", () => {
                 data: {},
                 extensions: { team_id: "Txxxxxxx", correlation_id: corrId, operationName: "Foor" },
                 secrets: [],
-            }, new QueuingWebSocketLifecycle());
+            }, new QueuingWebSocketLifecycle(), {});
 
         const msg: SlackMessage = {
             attachments: [{
@@ -93,7 +93,7 @@ describe("WebSocketMessageClient", () => {
                 data: {},
                 extensions: { team_id: "Txxxxxxx", correlation_id: corrId, operationName: "Foor" },
                 secrets: [],
-            }, new QueuingWebSocketLifecycle());
+            }, new QueuingWebSocketLifecycle(), {});
 
         const msg: SlackMessage = {
             attachments: [{
@@ -160,7 +160,7 @@ describe("WebSocketMessageClient", () => {
                 parameters: [],
                 mapped_parameters: [],
                 secrets: [],
-            }, new QueuingWebSocketLifecycle());
+            }, new QueuingWebSocketLifecycle(), {});
 
         const msg: SlackMessage = {
             attachments: [{
@@ -221,7 +221,7 @@ describe("WebSocketMessageClient", () => {
                 parameters: [],
                 mapped_parameters: [],
                 secrets: [],
-            }, new QueuingWebSocketLifecycle());
+            }, new QueuingWebSocketLifecycle(), {});
 
         const msg: SlackFileMessage = {
             content: "some basic text",

--- a/test/util/redact.test.ts
+++ b/test/util/redact.test.ts
@@ -1,26 +1,29 @@
 import { TransformableInfo } from "logform";
 import * as assert from "power-assert";
+import { DEFAULT_REDACTION_PATTERNS } from "../../lib/configuration";
 import {
-    addLogRedaction,
-    redact,
-} from "../../lib/util/logger";
-
-// require for its addLogRedaction calls
+    addRedaction,
+    redactLog,
+} from "../../lib/util/redact";
 // tslint:disable-next-line:no-var-requires
 require("../../lib/operations/common/AbstractRemoteRepoRef.ts");
 
-describe("util/logger", () => {
+describe("util/redact", () => {
 
     describe("redaction", () => {
+
+        before(() => {
+            DEFAULT_REDACTION_PATTERNS.forEach(d => addRedaction(d.regexp, d.replacement));
+        });
 
         it("redacts things", async () => {
             const replacement = "[DO NOT LOOK]";
 
             // sorry, but this will replace all booogers for the rest of the tests.
             // That is why I spelled it oddly.
-            addLogRedaction(/booo+gers/, replacement);
+            addRedaction(/booo+gers/, replacement);
 
-            const result = redact({
+            const result = redactLog({
                 message: "booogers and carrots",
             } as TransformableInfo);
 
@@ -30,9 +33,9 @@ describe("util/logger", () => {
 
         it("if the regexp has groups, redact those and not the whole thing", async () => {
 
-            addLogRedaction(/(84 )tomprince( \w+ )t\w+( nal)/, "$1[RIP_TOM]$2[RIP_TOM]$3");
+            addRedaction(/(84 )tomprince( \w+ )t\w+( nal)/, "$1[RIP_TOM]$2[RIP_TOM]$3");
 
-            const result = redact({
+            const result = redactLog({
                 message: "bujo84 tomprince malakai821 treguy nallaj",
             } as TransformableInfo);
 
@@ -42,7 +45,7 @@ describe("util/logger", () => {
 
         it("prints ordinary stuff", () => {
             const originalMessage = "boogers and carrots";
-            const result = redact({
+            const result = redactLog({
                 message: originalMessage,
             } as TransformableInfo);
 
@@ -51,7 +54,7 @@ describe("util/logger", () => {
 
         it("removes github token in username position", () => {
 
-            const result = redact({
+            const result = redactLog({
                 message: "https://12093847103847561098457012abfcdefab456ef:x-oauth-basic@blah blah blah blah",
             } as TransformableInfo);
 
@@ -62,7 +65,7 @@ describe("util/logger", () => {
 
         it("removes github token with x-oauth-basic", () => {
 
-            const result = redact({
+            const result = redactLog({
                 message: "https://12093847103847561098457012abfcdefab456ef@blah blah blah blah",
             } as TransformableInfo);
 
@@ -74,7 +77,7 @@ describe("util/logger", () => {
 
         //  `${this.scheme}${encodeURIComponent(creds.username)}:${encodeURIComponent(creds.password)}@`
         it("removes url auth password", () => {
-            const result = redact({
+            const result = redactLog({
                 message: "https://urlencoded%2Fusername:something%2Fpasswordy4785748@some.handy.website.com/things",
             } as TransformableInfo);
 
@@ -84,7 +87,7 @@ describe("util/logger", () => {
 
         // `${this.scheme}gitlab-ci-token:${creds.privateToken}@`
         it("removes gitlab ci token", () => {
-            const result = redact({
+            const result = redactLog({
                 message: "https://gitlab-ci-token:something-tokeny@blah blah blah blah",
             } as TransformableInfo);
 


### PR DESCRIPTION
Lets users configure redaction patterns and possible replacements in the configuration. Can be used to redact log and messages send via the message client.

By defaults installs redactions to hide GitHub tokens and user/passwords in urls.

fixes #526