### PR TITLE
Add toSubproject to InMemoryProject

### DIFF
--- a/lib/project/mem/InMemoryProject.ts
+++ b/lib/project/mem/InMemoryProject.ts
@@ -164,6 +164,25 @@ export class InMemoryProject extends AbstractProject {
         return Promise.reject(new Error("makeExecutable not implemented"));
     }
 
+    /**
+     * return a subproject of this one.
+     * This uses the SAME FILES.
+     */
+    public async toSubproject(subprojectPath: string): Promise<Project> {
+        // deliberately not using path.sep, because I don't want tests behaving differently by filesystem
+        const pathSeparator = "/";
+        const newRepoRef = {
+            ...this.id,
+            path: this.id.path + pathSeparator + subprojectPath,
+        };
+        const subp = new InMemoryProject(newRepoRef);
+        this.memFiles
+            .filter(f => f.path.startsWith(subprojectPath + pathSeparator))
+            .forEach(f => subp.memFiles.push(f));
+
+        return subp;
+    }
+
 }
 
 export function isInMemoryProject(p: Project): p is InMemoryProject {

--- a/lib/project/mem/InMemoryProject.ts
+++ b/lib/project/mem/InMemoryProject.ts
@@ -166,7 +166,7 @@ export class InMemoryProject extends AbstractProject {
 
     /**
      * return a subproject of this one.
-     * This uses the SAME FILES.
+     * This copies each file
      */
     public async toSubproject(subprojectPath: string): Promise<Project> {
         // deliberately not using path.sep, because I don't want tests behaving differently by filesystem
@@ -178,7 +178,9 @@ export class InMemoryProject extends AbstractProject {
         const subp = new InMemoryProject(newRepoRef);
         this.memFiles
             .filter(f => f.path.startsWith(subprojectPath + pathSeparator))
-            .forEach(f => subp.memFiles.push(f));
+            .forEach(f => {
+                subp.addFile(f.path.replace(subprojectPath + pathSeparator, ""), f.content);
+            });
 
         return subp;
     }


### PR DESCRIPTION
this is driven by a need in the org-visualizer, as we add support for monorepos. I expect that we will find need for this elsewhere. For now I'm not worried about adding it to the test class, and we can think about the abstraction later