### PR TITLE
Rework cluster shutdown

### DIFF
--- a/lib/internal/env/applicationEvent.ts
+++ b/lib/internal/env/applicationEvent.ts
@@ -1,4 +1,5 @@
 import * as appRoot from "app-root-path";
+// tslint:disable-next-line:import-blacklist
 import axios from "axios";
 import * as stringify from "json-stringify-safe";
 import * as os from "os";
@@ -64,11 +65,8 @@ export function registerApplicationEvents(workspaceId: string): Promise<any> {
     }
 
     // register shutdown hook
-    registerShutdownHook(() => {
-        return stopping(workspaceId, event)
-            .then(() => Promise.resolve(0))
-            .catch(() => Promise.resolve(1));
-    });
+    registerShutdownHook(() => stopping(workspaceId, event).then(() => Promise.resolve(0), () => Promise.resolve(1)),
+        2000, "application stopping event");
 
     // trigger application started event
     return started(workspaceId, event);

--- a/lib/internal/transport/cluster/ClusterMasterRequestProcessor.ts
+++ b/lib/internal/transport/cluster/ClusterMasterRequestProcessor.ts
@@ -23,7 +23,12 @@ import {
     HealthStatus,
     registerHealthIndicator,
 } from "../../util/health";
-import { registerShutdownHook } from "../../util/shutdown";
+import { poll } from "../../util/poll";
+import {
+    registerShutdownHook,
+    terminationGraceful,
+    terminationGracePeriod,
+} from "../../util/shutdown";
 import { AbstractRequestProcessor } from "../AbstractRequestProcessor";
 import {
     CommandIncoming,
@@ -52,19 +57,20 @@ interface MessageType {
     ts: number;
 }
 
+/* tslint:disable:max-file-line-count */
+
 /**
  * A RequestProcessor that delegates to Node.JS Cluster workers to do the actual
  * command and event processing.
  * @see ClusterWorkerRequestProcessor
  */
-export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
-    implements WebSocketRequestProcessor {
+export class ClusterMasterRequestProcessor extends AbstractRequestProcessor implements WebSocketRequestProcessor {
 
     private registration?: RegistrationConfirmation;
-    private webSocketLifecycle: WebSocketLifecycle;
-    private commands: Map<string, { dispatched: Dispatched<HandlerResult>, worker: number }> = new Map();
-    private events: Map<string, { dispatched: Dispatched<HandlerResult[]>, worker: number }> = new Map();
-    private messages: TinyQueue<MessageType> = new TinyQueue([], (a: MessageType, b: MessageType) => {
+    private readonly webSocketLifecycle: WebSocketLifecycle;
+    private readonly commands: Map<string, { dispatched: Dispatched<HandlerResult>, worker: number }> = new Map();
+    private readonly events: Map<string, { dispatched: Dispatched<HandlerResult[]>, worker: number }> = new Map();
+    private readonly messages: TinyQueue<MessageType> = new TinyQueue([], (a: MessageType, b: MessageType) => {
         if (a.message.type === "atomist:command" && b.message.type !== "atomist:command") {
             return -1;
         } else if (a.message.type !== "atomist:command" && b.message.type === "atomist:command") {
@@ -113,15 +119,27 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
             }
         });
 
-        registerShutdownHook(() => {
+        registerShutdownHook(async () => {
             this.shutdownInitiated = true;
-            return Promise.resolve(0);
-        }, Number.MIN_VALUE);
+            const gracePeriod = terminationGracePeriod(this.configuration);
+            if (terminationGraceful(this.configuration)) {
+                try {
+                    logger.debug("Waiting for queue to empty");
+                    await poll(() => this.queueLength() < 1, gracePeriod);
+                } catch (e) {
+                    logger.warn("Work queue did not empty within grace period");
+                    return 1;
+                }
+            }
+            logger.debug("Terminating workers");
+            await this.terminateWorkers(gracePeriod);
+            return 0;
+        }, 0, "drain work queue and shutdown workers");
 
         this.scheduleQueueLength();
     }
 
-    public onRegistration(registration: RegistrationConfirmation) {
+    public onRegistration(registration: RegistrationConfirmation): void {
         logger.info("Registration successful: %s", stringify(registration));
         (this.configuration.ws as any).session = registration;
         this.registration = registration;
@@ -129,19 +147,19 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
         broadcast({
             type: "atomist:registration",
             registration: this.registration,
-            context: null,
+            context: undefined,
         });
     }
 
-    public onConnect(ws: WebSocket) {
+    public onConnect(ws: WebSocket): void {
         logger.info("WebSocket connection established. Listening for incoming messages");
         this.webSocketLifecycle.set(ws);
         this.listeners.forEach(l => l.registrationSuccessful(this));
     }
 
-    public onDisconnect() {
+    public onDisconnect(): void {
         this.webSocketLifecycle.reset();
-        this.registration = null;
+        this.registration = undefined;
     }
 
     public run(): Promise<any> {
@@ -310,8 +328,10 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
         });
 
         cluster.on("exit", (worker, code, signal) => {
-            if (code !== 0 && !this.shutdownInitiated) {
-                logger.warn(`Worker '${worker.id}' exited with '${code}' '${signal}'. Restarting ...`);
+            if (this.shutdownInitiated) {
+                logger.info(`Worker '${worker.id}' shut down with status '${code}' and signal '${signal}'`);
+            } else {
+                logger.warn(`Worker '${worker.id}' exited with status '${code}' and signal '${signal}', replacing...`);
                 attachEvents(cluster.fork(), new Deferred());
             }
         });
@@ -322,7 +342,7 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
     protected invokeCommand(ci: CommandInvocation,
                             ctx: HandlerContext & AutomationContextAware,
                             command: CommandIncoming,
-                            callback: (result: Promise<HandlerResult>) => void) {
+                            callback: (result: Promise<HandlerResult>) => void): void {
         const message: MasterMessage = {
             type: "atomist:command",
             registration: this.registration,
@@ -340,7 +360,7 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
     protected invokeEvent(ef: EventFired<any>,
                           ctx: HandlerContext & AutomationContextAware,
                           event: EventIncoming,
-                          callback: (results: Promise<HandlerResult[]>) => void) {
+                          callback: (results: Promise<HandlerResult[]>) => void): void {
         const message: MasterMessage = {
             type: "atomist:event",
             registration: this.registration,
@@ -355,14 +375,12 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
         this.startMessage();
     }
 
-    protected sendStatusMessage(payload: any, ctx: HandlerContext & AutomationContextAware): Promise<any> {
-        return Promise.resolve(
-            this.webSocketLifecycle.send(payload),
-        );
+    protected async sendStatusMessage(payload: any, ctx: HandlerContext & AutomationContextAware): Promise<any> {
+        return this.webSocketLifecycle.send(payload);
     }
 
     protected createGraphClient(event: CommandIncoming | EventIncoming): GraphClient {
-        return null;
+        return undefined;
     }
 
     protected createMessageClient(event: CommandIncoming | EventIncoming): MessageClient {
@@ -444,6 +462,10 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
         this.reportQueueLength();
     }
 
+    private queueLength(): number {
+        return this.messages.length + this.events.size + this.commands.size;
+    }
+
     private scheduleQueueLength(): void {
         if (this.configuration.statsd.enabled) {
             setInterval(() => {
@@ -461,31 +483,42 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor
                     this.messages.length,
                     1,
                     [],
-                    () => { /* intentionally empty */
-                    });
+                    () => { /* intentionally empty */ },
+                );
                 statsd.gauge(
                     "work_queue.events",
                     this.events.size,
                     1,
                     [],
-                    () => { /* intentionally empty */
-                    });
+                    () => { /* intentionally empty */ },
+                );
                 statsd.gauge(
                     "work_queue.commands",
                     this.commands.size,
                     1,
                     [],
-                    () => { /* intentionally empty */
-                    });
+                    () => { /* intentionally empty */ },
+                );
             }
+        }
+    }
+
+    private async terminateWorkers(gracePeriod: number): Promise<void> {
+        const workerIds = Object.keys(cluster.workers).map(id => cluster.workers[id].id);
+        logger.debug("Sending workers the shutdown message");
+        workerIds.forEach(id => cluster.workers[id].send({ type: "atomist:shutdown" }));
+        try {
+            logger.debug("Waiting for workers to exit");
+            await poll(() => Object.keys(cluster.workers).length < 1, gracePeriod);
+            logger.debug("All workers have exited");
+        } catch (e) {
+            logger.warn(`Not all workers exited in allotted time: ${Object.keys(cluster.workers).join(",")}`);
         }
     }
 }
 
 class Dispatched<T> {
-
-    constructor(public result: Deferred<T>, public context: HandlerContext) {
-    }
+    constructor(public result: Deferred<T>, public context: HandlerContext) { }
 }
 
 function hydrateContext(msg: WorkerMessage): HandlerContext {

--- a/lib/internal/transport/websocket/WebSocketClient.ts
+++ b/lib/internal/transport/websocket/WebSocketClient.ts
@@ -20,14 +20,13 @@ import {
     RegistrationConfirmation,
     WebSocketRequestProcessor,
 } from "./WebSocketRequestProcessor";
-import Timer = NodeJS.Timer;
 
 export class WebSocketClient {
 
     public constructor(
-        private registrationCallback: () => any,
-        private configuration: Configuration,
-        private requestProcessor: WebSocketRequestProcessor,
+        private readonly registrationCallback: () => any,
+        private readonly configuration: Configuration,
+        private readonly requestProcessor: WebSocketRequestProcessor,
     ) {
     }
 
@@ -40,31 +39,13 @@ export class WebSocketClient {
 
             registerShutdownHook(() => {
                 reconnect = false;
-
-                if (this.configuration.ws.termination && this.configuration.ws.termination.graceful === true) {
-                    logger.info("Initiating WebSocket connection shutdown");
-
-                    // Now wait for configured timeout to let in-flight messages finish processing
-                    const deferred = new Deferred<number>();
-                    setTimeout(() => {
-                        ws.close();
-                        logger.info("Closing WebSocket connection");
-                        deferred.resolve(0);
-                    }, this.configuration.ws.termination.gracePeriod);
-
-                    return deferred.promise
-                        .then(code => {
-                            return code;
-                        });
-                } else {
-                    ws.close();
-                    logger.info("Closing WebSocket connection");
-                    return Promise.resolve(0);
-                }
-            });
+                logger.info("Closing WebSocket connection");
+                ws.close();
+                return Promise.resolve(0);
+            }, undefined /* last thing to do */, "closing websocket");
 
         }).catch(() => {
-            logger.error("Persistent error registering with Atomist. Exiting...");
+            logger.error("Persistent error registering with Atomist, exiting");
             process.exit(1);
         });
     }
@@ -81,11 +62,11 @@ function connect(registrationCallback: () => any,
                  requestProcessor: WebSocketRequestProcessor): Promise<WebSocket> {
 
     // Functions are inline to avoid "this" peculiarities
-    function invokeCommandHandler(chr: CommandIncoming) {
+    function invokeCommandHandler(chr: CommandIncoming): void {
         requestProcessor.processCommand(chr);
     }
 
-    function invokeEventHandler(e: EventIncoming) {
+    function invokeEventHandler(e: EventIncoming): void {
         requestProcessor.processEvent(e);
     }
 
@@ -94,9 +75,10 @@ function connect(registrationCallback: () => any,
         logger.info(`Opening WebSocket connection`);
         ws = configuration.ws.client.factory.create(registration);
 
-        let timer: Timer;
+        let timer: NodeJS.Timer;
 
-        ws.on("open", function open() {
+        ws.on("open", function open(): void {
+            // tslint:disable-next-line:no-invalid-this
             requestProcessor.onConnect(this);
             resolve(ws);
 
@@ -113,13 +95,14 @@ function connect(registrationCallback: () => any,
             }, 10000);
         });
 
-        ws.on("message", function incoming(data: WebSocket.Data) {
+        ws.on("message", function incoming(data: WebSocket.Data): void {
 
-            function handleMessage(request: string) {
+            function handleMessage(reqString: string): void {
+                let request: any;
                 try {
-                    request = JSON.parse(request);
+                    request = JSON.parse(reqString);
                 } catch (err) {
-                    logger.error(`Failed to parse incoming message: %s`, request);
+                    logger.error(`Failed to parse incoming message: %s`, reqString);
                     return;
                 }
 
@@ -140,7 +123,7 @@ function connect(registrationCallback: () => any,
                         }
                     }
                 } catch (err) {
-                    console.error("Failed processing of message payload with: %s", JSON.stringify(serializeError(err)));
+                    logger.error("Failed processing of message payload with: %s", JSON.stringify(serializeError(err)));
                 }
             }
 
@@ -179,7 +162,7 @@ function connect(registrationCallback: () => any,
             }
         });
 
-        function reset() {
+        function reset(): void {
             requestProcessor.onDisconnect();
             clearInterval(timer);
             ping = 0;
@@ -216,14 +199,14 @@ function register(registrationCallback: () => any,
         const authorization = `Bearer ${configuration.apiKey}`;
 
         return client.exchange<RegistrationConfirmation>(configuration.endpoints.api, {
-                body: registrationPayload,
-                method: HttpMethod.Post,
-                headers: { Authorization: authorization },
-                options: {
-                    timeout: configuration.ws.timeout,
-                },
-                retry: { retries: 0, log: false },
-            })
+            body: registrationPayload,
+            method: HttpMethod.Post,
+            headers: { Authorization: authorization },
+            options: {
+                timeout: configuration.ws.timeout,
+            },
+            retry: { retries: 0, log: false },
+        })
             .then(result => {
                 const registration = result.body;
 
@@ -253,17 +236,19 @@ function register(registrationCallback: () => any,
     });
 }
 
+/* tslint:disable:no-null-keyword */
 function isPing(a: any): a is Ping {
-    return a.ping != null;
+    return a.ping !== null && a.ping !== undefined;
 }
 
 function isPong(a: any): a is Pong {
-    return a.pong != null;
+    return a.pong !== null && a.pong !== undefined;
 }
 
 function isControl(a: any): a is Control {
-    return a.control != null;
+    return a.control !== null && a.control !== undefined;
 }
+/* tslint:enable:no-null-keyword */
 
 interface Ping {
     ping: string;

--- a/lib/internal/util/poll.ts
+++ b/lib/internal/util/poll.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Run a function periodically until it returns true or until the
+ * timeout expires.  Its polling period is 1/10th the timeout.  If the
+ * timeout expires before the function returns true, the Promise will
+ * be rejected.  The function will be tried immediately and when the
+ * total duration is reached.
+ *
+ * @param fn Function to call periodically
+ * @param duration Total length of time to poll in millisends
+ * @return Resolved Promise if function returns true within the timeout period, rejected Promise if not
+ */
+export async function poll(fn: () => boolean, duration: number = 1000): Promise<void> {
+    if (fn()) {
+        return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+        const period = duration / 10;
+        let interval: NodeJS.Timeout;
+        let timeout = setTimeout(() => {
+            if (interval) {
+                clearInterval(interval);
+                interval = undefined;
+            }
+            if (fn()) {
+                return resolve();
+            } else {
+                reject(new Error("Function did not return true in allotted time"));
+            }
+        }, duration);
+        interval = setInterval(() => {
+            if (fn()) {
+                if (timeout) {
+                    clearTimeout(timeout);
+                    timeout = undefined;
+                }
+                if (interval) {
+                    clearInterval(interval);
+                    interval = undefined;
+                }
+                resolve();
+            }
+        }, period);
+    });
+}
+
+/**
+ * Async sleep function.
+ *
+ * @param ms Sleep time in milliseconds.
+ */
+export function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/lib/internal/util/shutdown.ts
+++ b/lib/internal/util/shutdown.ts
@@ -1,31 +1,82 @@
 import * as exitHook from "async-exit-hook";
+import { get as _get } from "lodash";
+import { Configuration } from "../../configuration";
 import { logger } from "../../util/logger";
 
-let shutdownHooks: Array<{priority: number, hook: () => Promise<number>}> = [];
+/** Believe or not, this is the default grace period. */
+export const defaultGracePeriod = 10000;
 
-export function registerShutdownHook(cb: () => Promise<number>, priority: number = Number.MAX_VALUE) {
-    shutdownHooks = [{ priority, hook: cb }, ...shutdownHooks].sort((h1, h2) => h1.priority - h2.priority);
+/**
+ * Return whether graceful termination is enabled.
+ */
+export function terminationGraceful(cfg: Configuration): boolean {
+    return _get(cfg, "ws.termination.graceful", false);
 }
 
-exitHook.forceExitTimeout(60000 * 2);
-exitHook(callback => {
-    // Exit early if no shutdown hooks got registered
+/**
+ * Return graceful termination period in milliseconds.
+ */
+export function terminationGracePeriod(cfg: Configuration): number {
+    return _get(cfg, "ws.termination.gracePeriod", defaultGracePeriod);
+}
+
+/**
+ * Shutdown hook function and metadata.
+ */
+export interface ShutdownHook {
+    /** Function to call at shutdown. */
+    hook: () => Promise<number>;
+    /** Priority of hook.  Lower number values are executed first. */
+    priority: number;
+    /** Optional description used in logging. */
+    description?: string;
+}
+
+let shutdownHooks: ShutdownHook[] = [];
+
+/**
+ * Add callback to run when shutdown is initiated prior to process
+ * exit.  See [[ShutdownHook]] for description of parameters.
+ */
+export function registerShutdownHook(cb: () => Promise<number>, priority: number = Number.MAX_VALUE, desc?: string): void {
+    const description = desc || `Shutdown hook with priority ${priority}`;
+    shutdownHooks = [{ priority, hook: cb, description }, ...shutdownHooks].sort((h1, h2) => h1.priority - h2.priority);
+}
+
+/**
+ * Run each shutdown hook and collect its result.
+ */
+export async function executeShutdownHooks(cb: () => never): Promise<never> {
     if (shutdownHooks.length === 0) {
-        process.exit(0);
+        logger.info("Shutting down");
+        cb();
+        throw new Error(`async-exit-hook callback returned but should not have`);
     }
 
-    logger.info("Shutdown initiated. Calling shutdown hooks");
-    shutdownHooks
-        .map(h => h.hook)
-        .reduce((p, c, i, result) => p.then(c), Promise.resolve(0))
-        .then(result => {
-            logger.info("Shutdown hooks completed. Exiting...");
-            callback();
-            process.exit(result);
-        })
-        .catch(() => {
-            logger.info("Shutdown hooks failed. Exiting...");
-            callback();
-            process.exit(1);
-        });
-});
+    logger.info("Shutdown initiated, calling shutdown hooks");
+    let status = 0;
+    for (const hook of shutdownHooks) {
+        try {
+            logger.debug(`Calling shutdown hook '${hook.description}'...`);
+            const result = await hook.hook();
+            logger.debug(`Shutdown hook '${hook.description}' completed with status '${result}'`);
+            status += result;
+        } catch (e) {
+            logger.warn(`Shutdown hook '${hook.description}' threw an error: ${e.message}`);
+            status += 10;
+        }
+    }
+    logger.info(`Shutdown hooks completed with status '${status}', exiting`);
+    shutdownHooks = [];
+    cb();
+    throw new Error(`async-exit-hook callback returned but should not have`);
+}
+exitHook(executeShutdownHooks);
+
+/**
+ * Set the absolute longer number of milliseconds shutdown should
+ * take.
+ */
+export function setForceExitTimeout(ms: number): void {
+    exitHook.forceExitTimeout(ms);
+}

--- a/lib/spi/clone/StableDirectoryManager.ts
+++ b/lib/spi/clone/StableDirectoryManager.ts
@@ -40,7 +40,7 @@ export class StableDirectoryManager implements DirectoryManager {
 
     public opts: StableDirectoryManagerOpts;
 
-    private directoriesUsed = 0;
+    private directoriesUsed: number = 0;
 
     constructor(pOpts: StableDirectoryManagerOpts) {
         this.opts = {
@@ -52,7 +52,7 @@ export class StableDirectoryManager implements DirectoryManager {
             registerShutdownHook(() => {
                 logger.debug("Cleaning up temporary directories under '%s'", this.opts.baseDir);
                 return fs.remove(this.opts.baseDir).then(() => 0);
-            });
+            }, 3000, `directory cleanup: ${this.opts.baseDir}`);
         }
     }
 
@@ -85,7 +85,7 @@ export class StableDirectoryManager implements DirectoryManager {
      * Return undefined if not found
      */
     private existingDirectoryFor(owner: string, repo: string, branch: string,
-                                 opts: CloneOptions): Promise<CloneDirectoryInfo> {
+        opts: CloneOptions): Promise<CloneDirectoryInfo> {
         const expectedPath = this.pathFor(owner, repo);
         return fs.pathExists(expectedPath)
             .then(exists => {

--- a/test/action/actionChaining.test.ts
+++ b/test/action/actionChaining.test.ts
@@ -1,5 +1,4 @@
 import * as stringify from "json-stringify-safe";
-import "mocha";
 import * as assert from "power-assert";
 import * as TinyQueue from "tinyqueue";
 import { promisify } from "util";
@@ -10,12 +9,12 @@ import {
 } from "../../lib/action/actionOps";
 import { ActionResult } from "../../lib/action/ActionResult";
 import { MasterMessage } from "../../lib/internal/transport/cluster/messages";
+import { sleep } from "../../lib/internal/util/poll";
 import { GitHubRepoRef } from "../../lib/operations/common/GitHubRepoRef";
 import { InMemoryProject } from "../../lib/project/mem/InMemoryProject";
 
 class Person {
-    constructor(public name: string) {
-    }
+    constructor(public name: string) { }
 }
 
 describe("action chaining", () => {
@@ -142,19 +141,16 @@ describe("action chaining", () => {
         }).catch(done);
     });
 
-    const sleepPlease: (timeout: number) => Promise<void> =
-        promisify((a, b) => setTimeout(b, a));
-
     it("runs all of them for realz", done => {
         const report = [];
         const f1 = (s: string) => {
-            return sleepPlease(50).then(_ => {
+            return sleep(50).then(() => {
                 report.push("f1");
                 return Promise.resolve({ success: true, target: s + " and 1" });
             });
         };
         const f2 = (s: string) => {
-            return sleepPlease(50).then(_ => {
+            return sleep(50).then(() => {
                 report.push("f2");
                 return Promise.resolve({ success: true, target: s + " and 2" });
             });

--- a/test/util/child_process.test.ts
+++ b/test/util/child_process.test.ts
@@ -17,6 +17,7 @@
 
 import * as appRoot from "app-root-path";
 import * as assert from "power-assert";
+import { sleep } from "../../lib/internal/util/poll";
 import {
     execPromise,
     killProcess,
@@ -68,9 +69,6 @@ describe("child_promise", () => {
         });
 
         it("should not kill if signal handled", async () => {
-            function sleep(ms: number): Promise<void> {
-                return new Promise(resolve => setTimeout(resolve, ms));
-            }
             // delay to allow the spawned node process to start and set up signal handler
             const delay = 100;
             const script = "process.on('SIGTERM', function() { return; }); let t = setTimeout(function() { process.exit(7) }, 7000)";


### PR DESCRIPTION
The master organizes shutdown of a cluster, waiting for the queue to
empty and telling the workers to shutdown.  If the workers receive a
shutdown signal, they check and potentially wait to see if the master
has sent them a shutdown message.  If not, they shutdown anyway but at
least give themselves some time to complete work.  Configure max
shutdown timeout based on configured grace period.  Execute all
shutdown hooks, even if some throw an error.

Provide helper functions for graceful termination.  Add graceful
functionality to non-cluster mode.

If not shutting down, replace any worker that exits, regardless of
how.

Provide a sleep function.

Delint files I touched.

Towards #543

Maybe `termination` should be a top-level configuration property.
