### PR TITLE
Allow for normal exit with async hooks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -86,6 +86,7 @@ export {
 
 export {
     registerShutdownHook,
+    safeExit,
 } from "./lib/internal/util/shutdown";
 export {
     guid,

--- a/lib/globals.ts
+++ b/lib/globals.ts
@@ -5,7 +5,7 @@ import { EventStore } from "./spi/event/EventStore";
 ////////////////////////////////////////////////////////
 let es: EventStore;
 
-function initEventStore() {
+function initEventStore(): void {
     if (!es) {
         es = new InMemoryEventStore();
     }
@@ -20,7 +20,7 @@ export function eventStore(): EventStore {
     return es;
 }
 
-export function setEventStore(newEventStore: EventStore) {
+export function setEventStore(newEventStore: EventStore): void {
     es = newEventStore;
 }
 

--- a/lib/internal/transport/cluster/ClusterMasterRequestProcessor.ts
+++ b/lib/internal/transport/cluster/ClusterMasterRequestProcessor.ts
@@ -26,6 +26,7 @@ import {
 import { poll } from "../../util/poll";
 import {
     registerShutdownHook,
+    safeExit,
     terminationGraceful,
     terminationGracePeriod,
 } from "../../util/shutdown";
@@ -303,8 +304,11 @@ export class ClusterMasterRequestProcessor extends AbstractRequestProcessor impl
                                 this.startMessage();
                             });
                     } else if (msg.type === "atomist:shutdown") {
-                        logger.info(`Shutdown requested from worker`);
-                        process.kill(process.pid);
+                        logger.info(`Immediate shutdown requested from worker`);
+                        this.replaceWorkers = false;
+                        this.shutdownInitiated = true;
+                        this.configuration.ws.termination.graceful = false;
+                        safeExit(msg.data);
                     }
                 });
             });

--- a/lib/internal/transport/cluster/messages.ts
+++ b/lib/internal/transport/cluster/messages.ts
@@ -23,7 +23,7 @@ export interface WorkerMessage {
     data?: any;
 }
 
-export function broadcast(message: MasterMessage | MasterManagementMessage) {
+export function broadcast(message: MasterMessage | MasterManagementMessage): void {
     if (cluster.isMaster) {
         for (const id in cluster.workers) {
             if (cluster.workers.hasOwnProperty(id)) {

--- a/lib/internal/transport/websocket/WebSocketClient.ts
+++ b/lib/internal/transport/websocket/WebSocketClient.ts
@@ -42,7 +42,7 @@ export class WebSocketClient {
                 logger.info("Closing WebSocket connection");
                 ws.close();
                 return Promise.resolve(0);
-            }, undefined /* last thing to do */, "closing websocket");
+            }, 100000, "closing websocket");
 
         }).catch(() => {
             logger.error("Persistent error registering with Atomist, exiting");


### PR DESCRIPTION
Provide a means to process async shutdown hooks while returning a
specific exit status.  This is potentially breaking if user-provided
shutdown hooks using the default priority require that they execute
after the websocket is closed, which seems very unlikely.