### PR TITLE
Add a clone option to shallowly fetch all branches

### DIFF
--- a/lib/project/git/GitCommandGitProject.ts
+++ b/lib/project/git/GitCommandGitProject.ts
@@ -350,6 +350,9 @@ async function cloneInto(
             // if not cloning deeply, be sure we clone the right branch
             cloneArgs.push("--branch", cloneBranch);
         }
+        if (opts.noSingleBranch) {
+            cloneArgs.push("--no-single-branch");
+        }
     }
     // Note: branch takes preference for checkout because we might be about to commit to it.
     // If you want to be sure to land on your SHA, set opts.detachHead to true.

--- a/lib/spi/clone/DirectoryManager.ts
+++ b/lib/spi/clone/DirectoryManager.ts
@@ -16,6 +16,15 @@ export interface CloneOptions {
     alwaysDeep?: boolean;
 
     /**
+     * If we are not doing a deep clone (alwaysDeep is false),
+     * then the default is to clone only one branch.
+     * Set noSingleBranch to true to clone the tips of all branches instead.
+     * This passes `--no-single-branch` to `git clone`.
+     * If alwaysDeep is true, this option has no effect.
+     */
+    noSingleBranch?: boolean;
+
+    /**
      * Set this to the number of commits that should be cloned into the transient
      * place. This only applies when alwaysDeep is set to false.
      */

--- a/test/project/git/CachedGitClone.test.ts
+++ b/test/project/git/CachedGitClone.test.ts
@@ -261,8 +261,17 @@ describe("CachedGitClone", () => {
             // we can see all the commits
             assert(result.stdout.trim().split("\n").length > 1);
             const branchResult = await execPromise("git", ["rev-list", "this-tag-exists"], { cwd: baseDir });
-            // now we have access to branches
+            // now we have access to tags
             assert(branchResult.stdout.trim().split("\n").length >= 1);
+            await clone1.release();
+        }).timeout(20000);
+
+        it("clones all branches when requested", async () => {
+            const clone1 = await cloneTransiently({ alwaysDeep: false, noSingleBranch: true });
+            const baseDir = clone1.baseDir;
+            const result = await execPromise("git", ["rev-list", "origin/this-branch-exists"], { cwd: baseDir });
+            // we can see exactly one sha
+            assert(result.stdout.trim().length === 40);
             await clone1.release();
         }).timeout(20000);
     });


### PR DESCRIPTION
This is for org-visualizer, it wants to count branches but not fetch them deeply