### PR TITLE
Apply policy for TypeScript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "tinyqueue": "2.0.0",
     "tmp-promise": "^2.0.2",
     "tree-kill": "^1.2.1",
-    "typescript": "3.5.3",
+    "typescript": "^3.5.3",
     "utf8": "^3.0.0",
     "uuid": "^3.3.2",
     "winston": "^3.2.1",


### PR DESCRIPTION
Apply policy `typescript-version::typescript-version`:

_TypeScript Version_
```TypeScript version (^3.5.3)```

---
<details>
<summary>Commands</summary>
<br/>

You can trigger Atomist commands by commenting on this PR:
- `@atomist opt out` will stop raising automatic policy PRs for this repository
- `@atomist help` start your comment with this to ask Atomist for help or provide feedback

[Link this repository to a Slack channel](https://app.atomist.com/workspace/T29E48P34/settings/integrations/slack?repo=atomist%2Fautomation-client) to manage these updates directly from Slack.

</details>

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:typescript-version::typescript-version=65546ea5b01bb62f7b74c5d027cb8128f7cda8d5ae207501c0666411a403612d]</code>
</details>