### PR TITLE
Add support for code reloading without restart

### DIFF
--- a/bin/start-dev.ts
+++ b/bin/start-dev.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * See LICENSE file.
+ */
+
+// tslint:disable-next-line:no-import-side-effect
+import "source-map-support/register";
+
+import * as appRoot from "app-root-path";
+import * as _ from "lodash";
+import * as path from "path";
+import { printError } from "../lib/util/error";
+
+async function main(): Promise<void> {
+    try {
+        const logging = require("../lib/util/logger");
+        logging.configureLogging(logging.ClientLogging);
+
+        let cfg = await require("../lib/configuration").loadConfiguration();
+        cfg = require("../lib/scan").enableDefaultScanning(cfg);
+        cfg.logging.banner.contributors.push(
+            require("../lib/internal/transport/showStartupMessages").DevModeBannerContributor);
+
+        const automationClient = require("../lib/automationClient").automationClient(cfg);
+        await automationClient.run();
+        const registration = prepareRegistration(cfg);
+
+        const chokidar = require("chokidar");
+        const watcher = chokidar.watch(["index.js", "lib/*.js", "lib/**/*.js"], { ignored: "\.ts" });
+
+        const indexPath = path.join(appRoot.path, "index.js");
+        const libPath = path.join(appRoot.path, "lib");
+        const logger = logging.logger;
+
+        watcher.on("ready", () => {
+            watcher.on("all", async (e, path) => {
+                const start = Date.now();
+                logger.warn("Change to '%s' file detected. Attempting reload...", path);
+
+                Object.keys(require.cache).forEach(id => {
+                    if (id.startsWith(indexPath) || id.startsWith(libPath)) {
+                        delete require.cache[id];
+                    }
+                });
+
+                try {
+                    let newCfg = await require("../lib/configuration").loadConfiguration();
+                    newCfg = require("../lib/scan").enableDefaultScanning(newCfg);
+
+                    diffRegistration(prepareRegistration(newCfg), registration);
+
+                    // Clean out previous handlers and install new ones
+                    automationClient.automationServer.commandHandlers = [];
+                    newCfg.commands.forEach(c => automationClient.withCommandHandler(c));
+                    automationClient.automationServer.eventHandlers = [];
+                    newCfg.events.forEach(e => automationClient.withEventHandler(e));
+
+                    // Clean out the startup banner listeners
+                    if (automationClient.defaultListeners.length > 2) {
+                        automationClient.defaultListeners.splice(2);
+                    }
+                    await automationClient.raiseStartupEvent();
+
+                    logger.warn(`Reload successful in ${((Date.now() - start) / 1000).toFixed(2)}s`);
+                } catch (e) {
+                    logger.error("Reload failed");
+                    printError(e);
+                }
+            });
+        });
+
+    } catch (e) {
+        printError(e);
+        process.exit(5);
+    }
+}
+
+function prepareRegistration(configuration: any): any {
+    const automations = new (require("../lib/server/BuildableAutomationServer").BuildableAutomationServer)(configuration);
+    (configuration.commands || []).forEach(c => automations.registerCommandHandler(c));
+    (configuration.events || []).forEach(e => automations.registerEventHandler(e));
+    (configuration.ingesters || []).forEach(i => automations.registerIngester(i));
+    return require("../lib/internal/transport/websocket/payloads")
+        .prepareRegistration(automations.automations, {}, configuration.metadata);
+}
+
+function diffRegistration(newReg: any, oldReg: any): void {
+    if (!_.isEqual(newReg, oldReg)) {
+        const jsonDiff = require("json-diff");
+        const logging = require("../lib/util/logger");
+        logging.logger.error(
+            `Unable to reload. Incompatible changes to registration metadata detected:
+${jsonDiff.diffString(newReg, oldReg).trim()}`);
+        logging.logger.error("Exiting...");
+        process.exit(15);
+    }
+}
+
+main()
+    .catch(e => {
+        console.error(`Unhandled exception: ${e.message}`);
+        process.exit(10);
+    });

--- a/lib/internal/transport/showStartupMessages.ts
+++ b/lib/internal/transport/showStartupMessages.ts
@@ -3,10 +3,7 @@ import * as cluster from "cluster";
 import * as _ from "lodash";
 import { promisify } from "util";
 import { AutomationClient } from "../../automationClient";
-import {
-    BannerSection,
-    Configuration,
-} from "../../configuration";
+import { Configuration } from "../../configuration";
 import { AutomationEventListenerSupport } from "../../server/AutomationEventListener";
 import { logger } from "../../util/logger";
 import { Automations } from "../metadata/metadata";
@@ -31,6 +28,9 @@ export class StartupMessageAutomationEventListener extends AutomationEventListen
         }
     }
 }
+
+export const DevModeBannerContributor =
+    () => ({ title: "Development", body: chalk.green("Code reloading enabled") });
 
 /**
  * Build and log startup message, including any user banner

--- a/package-lock.json
+++ b/package-lock.json
@@ -1150,6 +1150,15 @@
       "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
       "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
     },
+    "anymatch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.0.tgz",
+      "integrity": "sha512-Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "apollo": {
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.18.0.tgz",
@@ -1649,6 +1658,11 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
       "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="
     },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -1705,6 +1719,14 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
       }
     },
     "browser-stdout": {
@@ -1915,10 +1937,58 @@
         }
       }
     },
+    "chokidar": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
+      "integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+      "requires": {
+        "anymatch": "^3.0.1",
+        "braces": "^3.0.2",
+        "fsevents": "^2.0.6",
+        "glob-parent": "^5.0.0",
+        "is-binary-path": "^2.1.0",
+        "is-glob": "^4.0.1",
+        "normalize-path": "^3.0.0",
+        "readdirp": "^3.1.1"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+          "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        }
+      }
+    },
     "clean-stack": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
       "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
+    },
+    "cli-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
+      "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
+      "requires": {
+        "es5-ext": "0.8.x"
+      },
+      "dependencies": {
+        "es5-ext": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz",
+          "integrity": "sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs="
+        }
+      }
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -2428,6 +2498,14 @@
       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
       "integrity": "sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg=="
     },
+    "difflib": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+      "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
+      "requires": {
+        "heap": ">= 0.2.0"
+      }
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2465,6 +2543,14 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz",
       "integrity": "sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA=="
+    },
+    "dreamopt": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
+      "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
+      "requires": {
+        "wordwrap": ">=0.0.2"
+      }
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -3143,6 +3229,14 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "optional": true
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -3250,6 +3344,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
+      "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -4115,6 +4215,11 @@
         "upper-case": "^1.1.3"
       }
     },
+    "heap": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
+    },
     "heavy": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/heavy/-/heavy-6.1.2.tgz",
@@ -4474,6 +4579,14 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-buffer": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
@@ -4547,6 +4660,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
       "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-object": {
       "version": "1.0.1",
@@ -4747,6 +4865,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+    },
+    "json-diff": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.5.4.tgz",
+      "integrity": "sha512-q5Xmx9QXNOzOzIlMoYtLrLiu4Jl/Ce2bn0CNcv54PhyH89CI4GWlGVDye8ei2Ijt9R3U+vsWPsXpLUNob8bs8Q==",
+      "requires": {
+        "cli-color": "~0.1.6",
+        "difflib": "~0.2.1",
+        "dreamopt": "~0.6.0"
+      }
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -5602,6 +5730,11 @@
         }
       }
     },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+    },
     "normalize-url": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
@@ -6425,6 +6558,14 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "readdirp": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
+      "integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
+      "requires": {
+        "picomatch": "^2.0.4"
+      }
+    },
     "recast": {
       "version": "0.18.2",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.18.2.tgz",
@@ -7119,6 +7260,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
     },
     "toidentifier": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "body-parser": "^1.18.3",
     "chalk": "^2.4.2",
     "child-process-promise": "^2.2.1",
+    "chokidar": "^3.0.2",
     "cluster": "^0.7.7",
     "cors": "^2.8.5",
     "cross-spawn": "^6.0.5",
@@ -98,6 +99,7 @@
     "https-proxy-agent": "^2.2.1",
     "inquirer": "^6.3.1",
     "isbinaryfile": "^4.0.0",
+    "json-diff": "^0.5.4",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.14",
     "lodash.merge": "^4.6.2",
@@ -186,7 +188,8 @@
     "atm-command": "./bin/command.js",
     "atm-git-info": "./bin/git-info.js",
     "atm-gql-gen": "./bin/gql-gen.js",
-    "atm-start": "./bin/start.js"
+    "atm-start": "./bin/start.js",
+    "atm-start-dev": "./bin/start-dev.js"
   },
   "engines": {
     "node": ">=8.2.0",


### PR DESCRIPTION
This adds a different `start-dev.js` script to the bin directory that starts the automation-client in a mode that reloads changes in the user code when there are changes to js files detected. 

As long as the user doesn't change metadata that would require a new registration to be made with the API, the changes are reloaded. If there are metadata changes (like changing the intent of a command handler) a diff is printed and the process exists.

This has no impact on running an automation-client with the current `start.js` script.

A corresponding PR on the atomist/cli will add a new `--dev` flag to `atomist start`.

Big thanks to @XertroV for the inspiration and some of the initial code.