### PR TITLE
Introduce caching to Project API

### DIFF
--- a/lib/project/File.ts
+++ b/lib/project/File.ts
@@ -1,9 +1,10 @@
 import { ScriptedFlushable } from "../internal/common/Flushable";
+import { HasCache } from "./HasCache";
 
 /**
  * Operations common to all File interfaces
  */
-export interface FileCore {
+export interface FileCore extends HasCache {
 
     /**
      * Return file name, excluding path

--- a/lib/project/HasCache.ts
+++ b/lib/project/HasCache.ts
@@ -1,9 +1,24 @@
-
+/**
+ * Extended by types that can hold cached data.
+ */
 export interface HasCache {
 
     /**
      * Use to cache arbitrary content associated with this instance.
      * Use for smallish objects that are expensive to compute.
+     * Be sure to use unique names. For example, do not store a property
+     * named "ast" - also include the name of the parser used to build it.
      */
     readonly cache: Record<string, object>;
+}
+
+/**
+ * Retrieve the value if stored in the cache. Otherwise compute with the given function
+ * and store
+ */
+export async function retrieveOrCompute<T extends HasCache, R extends object>(t: T, key: string, how: (t: T) => R): Promise<R> {
+    if (!t.cache[key]) {
+        t.cache[key] = await how(t);
+    }
+    return t.cache[key] as R;
 }

--- a/lib/project/HasCache.ts
+++ b/lib/project/HasCache.ts
@@ -1,0 +1,9 @@
+
+export interface HasCache {
+
+    /**
+     * Use to cache arbitrary content associated with this instance.
+     * Use for smallish objects that are expensive to compute.
+     */
+    readonly cache: Record<string, object>;
+}

--- a/lib/project/HasCache.ts
+++ b/lib/project/HasCache.ts
@@ -1,13 +1,8 @@
-/**
- * Extended by types that can hold cached data.
- */
 export interface HasCache {
 
     /**
      * Use to cache arbitrary content associated with this instance.
      * Use for smallish objects that are expensive to compute.
-     * Be sure to use unique names. For example, do not store a property
-     * named "ast" - also include the name of the parser used to build it.
      */
     readonly cache: Record<string, object>;
 }
@@ -16,7 +11,13 @@ export interface HasCache {
  * Retrieve the value if stored in the cache. Otherwise compute with the given function
  * and store
  */
-export async function retrieveOrCompute<T extends HasCache, R extends object>(t: T, key: string, how: (t: T) => R): Promise<R> {
+export async function retrieveOrCompute<T extends HasCache, R extends object>(t: T,
+                                                                              key: string,
+                                                                              how: (t: T) => R,
+                                                                              cache: boolean = true): Promise<R> {
+    if (!cache) {
+        return how(t);
+    }
     if (!t.cache[key]) {
         t.cache[key] = await how(t);
     }

--- a/lib/project/Project.ts
+++ b/lib/project/Project.ts
@@ -86,6 +86,13 @@ export interface ProjectSync extends ProjectCore {
 export interface ProjectAsync extends ProjectCore {
 
     /**
+     * Get files matching these patterns
+     * @param {string[]} globPatterns
+     * @return {Promise<File[]>}
+     */
+    getFiles(globPatterns?: string | string[]): Promise<File[]>;
+
+    /**
      * Return a node stream of the files in the project meeting
      * the given path criteria. Uses default exclusions in the glob path.
      * @param globPatterns glob patterns. If none is provided,

--- a/lib/project/Project.ts
+++ b/lib/project/Project.ts
@@ -11,6 +11,12 @@ export interface ProjectCore {
 
     id: RepoRef;
 
+    /**
+     * Use to cache arbitrary content associated with this Project instance.
+     * Use for smallish objects that are expensive to compute.
+     */
+    readonly cache: Record<string, object>;
+
 }
 
 /**
@@ -86,8 +92,8 @@ export interface ProjectSync extends ProjectCore {
 export interface ProjectAsync extends ProjectCore {
 
     /**
-     * Get files matching these patterns
-     * @param {string[]} globPatterns
+     * Get files matching these patterns glob patterns.
+     * @param {string[]} globPatterns. If none is supplied, return all files.
      * @return {Promise<File[]>}
      */
     getFiles(globPatterns?: string | string[]): Promise<File[]>;
@@ -98,6 +104,8 @@ export interface ProjectAsync extends ProjectCore {
      * @param globPatterns glob patterns. If none is provided,
      * include all files. If at least one positive pattern is provided,
      * one or more negative glob patterns can be provided.
+     *
+     * Prefer getFiles()
      *
      * @param {string[]} globPatterns glob patterns per minimatch
      * @return {FileStream}

--- a/lib/project/Project.ts
+++ b/lib/project/Project.ts
@@ -2,6 +2,7 @@ import { Stream } from "stream";
 import { RepoRef } from "../operations/common/RepoId";
 import { File } from "./File";
 import { HasCache } from "./HasCache";
+import { IOptions } from "minimatch";
 
 /**
  * Project operations common to all projects
@@ -115,7 +116,7 @@ export interface ProjectAsync extends ProjectCore {
      * @param opts for glob handling
      * @return {FileStream}
      */
-    streamFilesRaw(globPatterns: string[], opts: {}): FileStream;
+    streamFilesRaw(globPatterns: string[], opts: IOptions): FileStream;
 
     /**
      * The total number of files in this project or directory

--- a/lib/project/Project.ts
+++ b/lib/project/Project.ts
@@ -1,21 +1,16 @@
 import { Stream } from "stream";
 import { RepoRef } from "../operations/common/RepoId";
 import { File } from "./File";
+import { HasCache } from "./HasCache";
 
 /**
  * Project operations common to all projects
  */
-export interface ProjectCore {
+export interface ProjectCore extends HasCache {
 
     readonly name: string;
 
     id: RepoRef;
-
-    /**
-     * Use to cache arbitrary content associated with this Project instance.
-     * Use for smallish objects that are expensive to compute.
-     */
-    readonly cache: Record<string, object>;
 
 }
 

--- a/lib/project/Project.ts
+++ b/lib/project/Project.ts
@@ -1,8 +1,8 @@
+import { IOptions } from "minimatch";
 import { Stream } from "stream";
 import { RepoRef } from "../operations/common/RepoId";
 import { File } from "./File";
 import { HasCache } from "./HasCache";
-import { IOptions } from "minimatch";
 
 /**
  * Project operations common to all projects

--- a/lib/project/fileGlobs.ts
+++ b/lib/project/fileGlobs.ts
@@ -1,10 +1,7 @@
 /**
- * Glob pattern to match all files in a project. Standard glob syntax
- * @type {string}
+ * Glob pattern to match all files in a project. Standard glob syntax.
  */
 export const AllFiles = "**/**";
-
-export const AllDotFiles = ".**/**";
 
 /**
  * Negative glob to exclude .git directory
@@ -32,4 +29,4 @@ export const DefaultExcludes = [ExcludeGit, ExcludeNodeModules, ExcludeTarget];
  * Include all files except with default exclusions (git and node modules)
  * @type {[string , string , string]}
  */
-export const DefaultFiles = [AllFiles, AllDotFiles].concat(DefaultExcludes);
+export const DefaultFiles = [AllFiles].concat(DefaultExcludes);

--- a/lib/project/fileGlobs.ts
+++ b/lib/project/fileGlobs.ts
@@ -2,7 +2,9 @@
  * Glob pattern to match all files in a project. Standard glob syntax
  * @type {string}
  */
-export const AllFiles = "**";
+export const AllFiles = "**/**";
+
+export const AllDotFiles = ".**/**";
 
 /**
  * Negative glob to exclude .git directory
@@ -30,4 +32,4 @@ export const DefaultExcludes = [ExcludeGit, ExcludeNodeModules, ExcludeTarget];
  * Include all files except with default exclusions (git and node modules)
  * @type {[string , string , string]}
  */
-export const DefaultFiles = [AllFiles].concat(DefaultExcludes);
+export const DefaultFiles = [AllFiles, AllDotFiles].concat(DefaultExcludes);

--- a/lib/project/local/NodeFsLocalProject.ts
+++ b/lib/project/local/NodeFsLocalProject.ts
@@ -48,7 +48,6 @@ export class NodeFsLocalProject extends AbstractProject implements LocalProject 
      * Copy the contents of the other project to this project
      * @param {Project} other
      * @param {string} baseDir
-     * @param newName new name of the project. Defaults to name of old project
      * @param cleanup
      * @returns {LocalProject}
      */
@@ -104,17 +103,20 @@ export class NodeFsLocalProject extends AbstractProject implements LocalProject 
     }
 
     public addFileSync(path: string, content: string): void {
+        this.invalidateCache();
         const realName = this.toRealPath(path);
         fs.outputFileSync(realName, content);
     }
 
     public async addFile(path: string, content: string): Promise<this> {
+        this.invalidateCache();
         const realName = this.toRealPath(path);
         await fs.outputFile(realName, content);
         return this;
     }
 
     public async addDirectory(path: string): Promise<this> {
+        this.invalidateCache();
         const realName = this.toRealPath(path);
         await fs.ensureDir(realName);
         return this;
@@ -123,6 +125,7 @@ export class NodeFsLocalProject extends AbstractProject implements LocalProject 
     public async deleteDirectory(path: string): Promise<this> {
         try {
             await fs.remove(this.toRealPath(path));
+            this.invalidateCache();
         } catch (e) {
             logger.debug("Unable to delete directory '%s': %s", path, e.message);
         }
@@ -133,6 +136,7 @@ export class NodeFsLocalProject extends AbstractProject implements LocalProject 
         const localPath = this.toRealPath(path);
         try {
             fs.removeSync(localPath);
+            this.invalidateCache();
         } catch (e) {
             logger.debug("Unable to delete directory '%s': %s", path, e.message);
         }
@@ -141,6 +145,7 @@ export class NodeFsLocalProject extends AbstractProject implements LocalProject 
     public deleteFileSync(path: string): void {
         try {
             fs.unlinkSync(this.toRealPath(path));
+            this.invalidateCache();
         } catch (e) {
             logger.debug("Unable to delete file '%s': %s", path, e.message);
         }
@@ -149,6 +154,7 @@ export class NodeFsLocalProject extends AbstractProject implements LocalProject 
     public async deleteFile(path: string): Promise<this> {
         try {
             await fs.unlink(this.toRealPath(path));
+            this.invalidateCache();
         } catch (e) {
             logger.debug("Unable to delete file '%s': %s", path, e.message);
         }

--- a/lib/project/mem/InMemoryProject.ts
+++ b/lib/project/mem/InMemoryProject.ts
@@ -10,7 +10,10 @@ import {
     FileStream,
     Project,
 } from "../Project";
-import { AbstractProject, globMatchesWithin } from "../support/AbstractProject";
+import {
+    AbstractProject,
+    globMatchesWithin,
+} from "../support/AbstractProject";
 import { copyFiles } from "../support/projectUtils";
 import { InMemoryFile } from "./InMemoryFile";
 

--- a/lib/project/mem/InMemoryProject.ts
+++ b/lib/project/mem/InMemoryProject.ts
@@ -1,6 +1,7 @@
 
 import * as spigot from "stream-spigot";
 
+import { IOptions } from "minimatch";
 import { RepoRef } from "../../operations/common/RepoId";
 import {
     File,
@@ -16,7 +17,6 @@ import {
 } from "../support/AbstractProject";
 import { copyFiles } from "../support/projectUtils";
 import { InMemoryFile } from "./InMemoryFile";
-import { IOptions } from "minimatch";
 
 /**
  * In memory Project implementation. Primarily intended

--- a/lib/project/mem/InMemoryProject.ts
+++ b/lib/project/mem/InMemoryProject.ts
@@ -11,7 +11,7 @@ import {
     FileStream,
     Project,
 } from "../Project";
-import { AbstractProject } from "../support/AbstractProject";
+import { AbstractProject, globMatchesWithin } from "../support/AbstractProject";
 import { copyFiles } from "../support/projectUtils";
 import { InMemoryFile } from "./InMemoryFile";
 
@@ -148,13 +148,7 @@ export class InMemoryProject extends AbstractProject {
     }
 
     public streamFilesRaw(globPatterns: string[], opts: {}): FileStream {
-        const positiveMatches = _.flatten(
-            this.memFiles.filter(f =>
-                globPatterns.some(gp => !gp.startsWith("!") && minimatch.match([f.path], gp).includes(f.path)),
-            ));
-        const matchingFiles = _.reject(positiveMatches,
-            f => globPatterns.some(gp => gp.startsWith("!") && minimatch.match([f.path], gp.substring(1)).includes(f.path)),
-        );
+        const matchingFiles = globMatchesWithin(this.memFiles, globPatterns);
         return spigot.array({ objectMode: true },
             matchingFiles,
         );

--- a/lib/project/mem/InMemoryProject.ts
+++ b/lib/project/mem/InMemoryProject.ts
@@ -16,6 +16,7 @@ import {
 } from "../support/AbstractProject";
 import { copyFiles } from "../support/projectUtils";
 import { InMemoryFile } from "./InMemoryFile";
+import { IOptions } from "minimatch";
 
 /**
  * In memory Project implementation. Primarily intended
@@ -154,8 +155,8 @@ export class InMemoryProject extends AbstractProject {
         return this.memFiles.some(f => f.path === path);
     }
 
-    public streamFilesRaw(globPatterns: string[], opts: {}): FileStream {
-        const matchingFiles = globMatchesWithin(this.memFiles, globPatterns);
+    public streamFilesRaw(globPatterns: string[], opts: IOptions): FileStream {
+        const matchingFiles = globMatchesWithin(this.memFiles, globPatterns, opts);
         return spigot.array({ objectMode: true },
             matchingFiles,
         );

--- a/lib/project/mem/InMemoryProject.ts
+++ b/lib/project/mem/InMemoryProject.ts
@@ -1,5 +1,4 @@
-import * as _ from "lodash";
-import * as minimatch from "minimatch";
+
 import * as spigot from "stream-spigot";
 
 import { RepoRef } from "../../operations/common/RepoId";
@@ -68,7 +67,7 @@ export class InMemoryProject extends AbstractProject {
         super(xid);
     }
 
-    get fileCount() {
+    get fileCount(): number {
         return this.memFiles.length;
     }
 
@@ -90,6 +89,7 @@ export class InMemoryProject extends AbstractProject {
     }
 
     public recordAddFile(path: string, content: string): this {
+        this.invalidateCache();
         this.memFiles.push(new InMemoryFile(path, content));
         return this;
     }
@@ -104,11 +104,13 @@ export class InMemoryProject extends AbstractProject {
     }
 
     public addDirectory(path: string): Promise<this> {
+        this.invalidateCache();
         this.addedDirectoryPaths.push(path);
         return Promise.resolve(this);
     }
 
     public deleteDirectorySync(path: string): void {
+        this.invalidateCache();
         this.memFiles.forEach(f => {
             if (f.path.startsWith(`${path}/`)) {
                 this.deleteFileSync(f.path);
@@ -117,11 +119,13 @@ export class InMemoryProject extends AbstractProject {
     }
 
     public deleteDirectory(path: string): Promise<this> {
+        this.invalidateCache();
         this.deleteDirectorySync(path);
         return Promise.resolve(this);
     }
 
     public deleteFileSync(path: string): this {
+        this.invalidateCache();
         this.memFiles = this.memFiles.filter(f => f.path !== path);
         return this;
     }

--- a/lib/project/support/AbstractFile.ts
+++ b/lib/project/support/AbstractFile.ts
@@ -8,6 +8,8 @@ export abstract class AbstractFile extends AbstractScriptedFlushable<File> imple
 
     public abstract path: string;
 
+    public readonly cache: Record<string, object> = {};
+
     get name(): string {
         return this.path.split("/").pop();
     }

--- a/lib/project/support/AbstractProject.ts
+++ b/lib/project/support/AbstractProject.ts
@@ -16,7 +16,6 @@ import {
 import * as _ from "lodash";
 
 import * as minimatch from "minimatch";
-import { toArray } from "lodash";
 
 /**
  * Support for implementations of Project interface
@@ -66,6 +65,9 @@ export abstract class AbstractProject extends AbstractScriptedFlushable<Project>
      * @return {Promise<File[]>}
      */
     public async getFiles(globPatterns: string | string[] = []): Promise<File[]> {
+        const globPatternsToUse = globPatterns ?
+            (typeof globPatterns === "string" ? [globPatterns] : globPatterns) :
+            [];
         if (this.cachedFiles) {
             return this.cachedFiles;
         }
@@ -77,7 +79,7 @@ export abstract class AbstractProject extends AbstractScriptedFlushable<Project>
                 .on("end", _ => resolve(this.cachedFiles));
         });
         return globPatterns ?
-            globMatchesWithin(this.cachedFiles, toArray(globPatterns)) :
+            globMatchesWithin(this.cachedFiles, globPatternsToUse) :
             this.cachedFiles;
     }
 
@@ -137,6 +139,10 @@ export abstract class AbstractProject extends AbstractScriptedFlushable<Project>
     public abstract directoryExistsSync(path: string): boolean;
 
     public abstract fileExistsSync(path: string): boolean;
+
+    protected invalidateCache(): void {
+        this.cachedFiles = undefined;
+    }
 
 }
 

--- a/lib/project/support/AbstractProject.ts
+++ b/lib/project/support/AbstractProject.ts
@@ -1,3 +1,4 @@
+import * as _ from "lodash";
 import { AbstractScriptedFlushable } from "../../internal/common/AbstractScriptedFlushable";
 import { RepoRef } from "../../operations/common/RepoId";
 import { logger } from "../../util/logger";
@@ -13,7 +14,6 @@ import {
     FileStream,
     Project,
 } from "../Project";
-import * as _ from "lodash";
 
 import * as minimatch from "minimatch";
 

--- a/lib/project/support/AbstractProject.ts
+++ b/lib/project/support/AbstractProject.ts
@@ -27,6 +27,8 @@ export abstract class AbstractProject extends AbstractScriptedFlushable<Project>
      */
     private cachedFiles: File[];
 
+    public readonly cache: Record<string, object> = {};
+
     get name(): string {
         return !!this.id ? this.id.repo : undefined;
     }

--- a/lib/project/support/AbstractProject.ts
+++ b/lib/project/support/AbstractProject.ts
@@ -14,8 +14,8 @@ import {
     Project,
 } from "../Project";
 
-import * as multimatch from "multimatch";
 import { IOptions } from "minimatch";
+import * as multimatch from "multimatch";
 
 /**
  * Support for implementations of Project interface

--- a/lib/project/support/AbstractProject.ts
+++ b/lib/project/support/AbstractProject.ts
@@ -1,4 +1,3 @@
-import * as _ from "lodash";
 import { AbstractScriptedFlushable } from "../../internal/common/AbstractScriptedFlushable";
 import { RepoRef } from "../../operations/common/RepoId";
 import { logger } from "../../util/logger";
@@ -15,7 +14,7 @@ import {
     Project,
 } from "../Project";
 
-import * as minimatch from "minimatch";
+import * as multimatch from "multimatch";
 
 /**
  * Support for implementations of Project interface
@@ -145,16 +144,14 @@ export abstract class AbstractProject extends AbstractScriptedFlushable<Project>
 
 }
 
+/**
+ * Return the files that match these glob patterns, including negative globs
+ */
 export function globMatchesWithin(files: File[], globPatterns?: string[]): File[] {
     if (!globPatterns || globPatterns.length === 0) {
         return files;
     }
-    const positiveMatches = _.flatten(
-        files.filter(f =>
-            globPatterns.some(gp => !gp.startsWith("!") && minimatch.match([f.path], gp).includes(f.path)),
-        ));
-    const matchingFiles = _.reject(positiveMatches,
-        f => globPatterns.some(gp => gp.startsWith("!") && minimatch.match([f.path], gp.substring(1)).includes(f.path)),
-    );
-    return matchingFiles;
+    const paths = files.map(f => f.path);
+    const matchingPaths = multimatch(paths, globPatterns);
+    return files.filter(f => matchingPaths.includes(f.path));
 }

--- a/lib/project/support/AbstractProject.ts
+++ b/lib/project/support/AbstractProject.ts
@@ -15,6 +15,7 @@ import {
 } from "../Project";
 
 import * as multimatch from "multimatch";
+import { IOptions } from "minimatch";
 
 /**
  * Support for implementations of Project interface
@@ -55,7 +56,7 @@ export abstract class AbstractProject extends AbstractScriptedFlushable<Project>
 
     public streamFiles(...globPatterns: string[]): FileStream {
         const globsToUse = globPatterns.length > 0 ? globPatterns.concat(DefaultExcludes) : DefaultFiles;
-        return this.streamFilesRaw(globsToUse, {});
+        return this.streamFilesRaw(globsToUse, { dot: true });
     }
 
     public abstract streamFilesRaw(globPatterns: string[], opts: {}): FileStream;
@@ -147,11 +148,11 @@ export abstract class AbstractProject extends AbstractScriptedFlushable<Project>
 /**
  * Return the files that match these glob patterns, including negative globs
  */
-export function globMatchesWithin(files: File[], globPatterns?: string[]): File[] {
+export function globMatchesWithin(files: File[], globPatterns?: string[], opts?: IOptions): File[] {
     if (!globPatterns || globPatterns.length === 0) {
         return files;
     }
     const paths = files.map(f => f.path);
-    const matchingPaths = multimatch(paths, globPatterns);
+    const matchingPaths = multimatch(paths, globPatterns, opts);
     return files.filter(f => matchingPaths.includes(f.path));
 }

--- a/lib/project/util/projectUtils.ts
+++ b/lib/project/util/projectUtils.ts
@@ -70,23 +70,26 @@ export async function countFiles<T>(p: ProjectAsync,
  * Undefined returns will be filtered out
  * @return {Promise<T[]>}
  */
-export function gatherFromFiles<T>(project: ProjectAsync,
-                                   globPatterns: GlobOptions,
-                                   gather: (f: File) => Promise<T> | undefined): Promise<T[]> {
-    return new Promise((resolve, reject) => {
-        const gathered: Array<Promise<T>> = [];
-        project.streamFiles(...toStringArray(globPatterns))
-            .on("data", f => {
-                const g = gather(f);
-                if (g) {
-                    gathered.push(g);
-                }
-            })
-            .on("error", reject)
-            .on("end", _ => {
-                resolve(Promise.all(gathered).then(ts => ts.filter(t => !!t)));
-            });
-    });
+export async function gatherFromFiles<T>(project: ProjectAsync,
+                                         globPatterns: GlobOptions,
+                                         gather: (f: File) => Promise<T> | undefined): Promise<T[]> {
+    // return new Promise((resolve, reject) => {
+    //     const gathered: Array<Promise<T>> = [];
+    //     project.streamFiles(...toStringArray(globPatterns))
+    //         .on("data", f => {
+    //             const g = gather(f);
+    //             if (g) {
+    //                 gathered.push(g);
+    //             }
+    //         })
+    //         .on("error", reject)
+    //         .on("end", _ => {
+    //             resolve(Promise.all(gathered).then(ts => ts.filter(t => !!t)));
+    //         });
+    // });
+    const allFiles = await project.getFiles(globPatterns);
+    const matches = allFiles.map(gather);
+    return (await Promise.all(matches)).filter(t => !!t);
 }
 
 /**

--- a/lib/project/util/projectUtils.ts
+++ b/lib/project/util/projectUtils.ts
@@ -73,20 +73,6 @@ export async function countFiles<T>(p: ProjectAsync,
 export async function gatherFromFiles<T>(project: ProjectAsync,
                                          globPatterns: GlobOptions,
                                          gather: (f: File) => Promise<T> | undefined): Promise<T[]> {
-    // return new Promise((resolve, reject) => {
-    //     const gathered: Array<Promise<T>> = [];
-    //     project.streamFiles(...toStringArray(globPatterns))
-    //         .on("data", f => {
-    //             const g = gather(f);
-    //             if (g) {
-    //                 gathered.push(g);
-    //             }
-    //         })
-    //         .on("error", reject)
-    //         .on("end", _ => {
-    //             resolve(Promise.all(gathered).then(ts => ts.filter(t => !!t)));
-    //         });
-    // });
     const allFiles = await project.getFiles(globPatterns);
     const matches = allFiles.map(gather);
     return (await Promise.all(matches)).filter(t => !!t);

--- a/lib/tree/ast/FileHits.ts
+++ b/lib/tree/ast/FileHits.ts
@@ -119,11 +119,11 @@ function requireOffset(m: MatchResult) {
     }
 }
 
-function makeUpdatable(matches: MatchResult[], updates: Update[]) {
+function makeUpdatable(matches: MatchResult[], updates: Update[]): void {
     matches.forEach(m => {
         const initialValue = m.$value;
         let currentValue = m.$value;
-        if (!m.$value) {
+        try {
             Object.defineProperty(m, "$value", {
                 get() {
                     return currentValue;
@@ -136,6 +136,8 @@ function makeUpdatable(matches: MatchResult[], updates: Update[]) {
                     updates.push({ initialValue, currentValue, offset: m.$offset });
                 },
             });
+        } catch {
+            // Ok
         }
         m.append = (content: string) => {
             requireOffset(m);

--- a/lib/tree/ast/FileHits.ts
+++ b/lib/tree/ast/FileHits.ts
@@ -12,7 +12,6 @@ import {
 } from "../../project/Project";
 import { logger } from "../../util/logger";
 import { LocatedTreeNode } from "../LocatedTreeNode";
-import { ExecutionResult } from "@atomist/tree-path/lib/path/pathExpression";
 
 /**
  * Options for handling production replacements
@@ -37,20 +36,20 @@ export const ZapTrailingWhitespace: NodeReplacementOptions = {
  */
 export interface MatchResult extends LocatedTreeNode {
 
-    append(content: string): void;
+    append(content: string);
 
-    prepend(content: string): void;
+    prepend(content: string);
 
     /**
      * Delete the match. Same as setting $value to the empty string,
      * but can zap trailing spaces also
      * @param {NodeReplacementOptions} opts
      */
-    zap(opts: NodeReplacementOptions): void;
+    zap(opts: NodeReplacementOptions);
 
-    replace(newContent: string, opts: NodeReplacementOptions): void;
+    replace(newContent: string, opts: NodeReplacementOptions);
 
-    evaluateExpression(pex: string | PathExpression): ExecutionResult;
+    evaluateExpression(pex: string | PathExpression);
 }
 
 interface Update extends NodeReplacementOptions {
@@ -119,24 +118,22 @@ function requireOffset(m: MatchResult) {
     }
 }
 
-function makeUpdatable(matches: MatchResult[], updates: Update[]): void {
+function makeUpdatable(matches: MatchResult[], updates: Update[]) {
     matches.forEach(m => {
         const initialValue = m.$value;
         let currentValue = m.$value;
-        if (!m.$value) {
-            Object.defineProperty(m, "$value", {
-                get() {
-                    return currentValue;
-                },
-                set(v2) {
-                    logger.debug("Updating value from '%s' to '%s' on '%s'", currentValue, v2, m.$name);
-                    // TODO allow only one
-                    currentValue = v2;
-                    requireOffset(m);
-                    updates.push({ initialValue, currentValue, offset: m.$offset });
-                },
-            });
-        }
+        Object.defineProperty(m, "$value", {
+            get() {
+                return currentValue;
+            },
+            set(v2) {
+                logger.debug("Updating value from '%s' to '%s' on '%s'", currentValue, v2, m.$name);
+                // TODO allow only one
+                currentValue = v2;
+                requireOffset(m);
+                updates.push({ initialValue, currentValue, offset: m.$offset });
+            },
+        });
         m.append = (content: string) => {
             requireOffset(m);
             updates.push({ initialValue: "", currentValue: content, offset: m.$offset + currentValue.length });

--- a/lib/tree/ast/FileHits.ts
+++ b/lib/tree/ast/FileHits.ts
@@ -4,6 +4,7 @@ import {
     PathExpression,
     TreeNode,
 } from "@atomist/tree-path";
+import { ExecutionResult } from "@atomist/tree-path/lib/path/pathExpression";
 import { ScriptedFlushable } from "../../internal/common/Flushable";
 import { File } from "../../project/File";
 import {
@@ -12,7 +13,6 @@ import {
 } from "../../project/Project";
 import { logger } from "../../util/logger";
 import { LocatedTreeNode } from "../LocatedTreeNode";
-import { ExecutionResult } from "@atomist/tree-path/lib/path/pathExpression";
 
 /**
  * Options for handling production replacements

--- a/lib/tree/ast/FileHits.ts
+++ b/lib/tree/ast/FileHits.ts
@@ -12,6 +12,7 @@ import {
 } from "../../project/Project";
 import { logger } from "../../util/logger";
 import { LocatedTreeNode } from "../LocatedTreeNode";
+import { ExecutionResult } from "@atomist/tree-path/lib/path/pathExpression";
 
 /**
  * Options for handling production replacements
@@ -36,20 +37,20 @@ export const ZapTrailingWhitespace: NodeReplacementOptions = {
  */
 export interface MatchResult extends LocatedTreeNode {
 
-    append(content: string);
+    append(content: string): void;
 
-    prepend(content: string);
+    prepend(content: string): void;
 
     /**
      * Delete the match. Same as setting $value to the empty string,
      * but can zap trailing spaces also
      * @param {NodeReplacementOptions} opts
      */
-    zap(opts: NodeReplacementOptions);
+    zap(opts: NodeReplacementOptions): void;
 
-    replace(newContent: string, opts: NodeReplacementOptions);
+    replace(newContent: string, opts: NodeReplacementOptions): void;
 
-    evaluateExpression(pex: string | PathExpression);
+    evaluateExpression(pex: string | PathExpression): ExecutionResult;
 }
 
 interface Update extends NodeReplacementOptions {
@@ -118,22 +119,24 @@ function requireOffset(m: MatchResult) {
     }
 }
 
-function makeUpdatable(matches: MatchResult[], updates: Update[]) {
+function makeUpdatable(matches: MatchResult[], updates: Update[]): void {
     matches.forEach(m => {
         const initialValue = m.$value;
         let currentValue = m.$value;
-        Object.defineProperty(m, "$value", {
-            get() {
-                return currentValue;
-            },
-            set(v2) {
-                logger.debug("Updating value from '%s' to '%s' on '%s'", currentValue, v2, m.$name);
-                // TODO allow only one
-                currentValue = v2;
-                requireOffset(m);
-                updates.push({ initialValue, currentValue, offset: m.$offset });
-            },
-        });
+        if (!m.$value) {
+            Object.defineProperty(m, "$value", {
+                get() {
+                    return currentValue;
+                },
+                set(v2) {
+                    logger.debug("Updating value from '%s' to '%s' on '%s'", currentValue, v2, m.$name);
+                    // TODO allow only one
+                    currentValue = v2;
+                    requireOffset(m);
+                    updates.push({ initialValue, currentValue, offset: m.$offset });
+                },
+            });
+        }
         m.append = (content: string) => {
             requireOffset(m);
             updates.push({ initialValue: "", currentValue: content, offset: m.$offset + currentValue.length });

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -18,6 +18,7 @@ import {
     NestedPathExpressionPredicate,
 } from "@atomist/tree-path/lib/path/predicates";
 import { File } from "../../project/File";
+import { retrieveOrCompute } from "../../project/HasCache";
 import {
     Project,
     ProjectAsync,
@@ -39,7 +40,6 @@ import {
     isFileParser,
 } from "./FileParser";
 import { FileParserRegistry } from "./FileParserRegistry";
-import { retrieveOrCompute } from "../../project/HasCache";
 
 /**
  * Create a MatchTester to use against this file, caching

--- a/lib/tree/ast/astUtils.ts
+++ b/lib/tree/ast/astUtils.ts
@@ -234,14 +234,13 @@ async function parseFile(parser: FileParser,
 
     // If we get here, we need to parse the file
     try {
-        // Use a cached AST if possible
-        const topLevelProduction = cacheAst ?
-            await retrieveOrCompute(file, `ast_${parser.rootName}`, async f => {
+        // Use a cached AST if appropriate
+        const topLevelProduction = await retrieveOrCompute(file, `ast_${parser.rootName}`, async f => {
                 const prod = await parser.toAst(f);
                 defineDynamicProperties(prod);
                 return prod;
-            }) :
-            await parser.toAst(file);
+            }, cacheAst);
+
         logger.debug("Successfully parsed file '%s' to AST with root node named '%s'. Will execute '%s'",
             file.path, topLevelProduction.$name, stringify(pex));
         const fileNode = {
@@ -352,7 +351,7 @@ export async function doWithAllMatches<P extends ProjectAsync = ProjectAsync>(p:
     return (p as any).flush();
 }
 
-function applyActionToMatches(fh: FileHit, action: (m: MatchResult) => void) {
+function applyActionToMatches(fh: FileHit, action: (m: MatchResult) => void): void {
     // Sort file hits in reverse order so that offsets aren't upset by applications
     const sorted = fh.matches.sort((m1, m2) => m1.$offset - m2.$offset);
     sorted.forEach(action);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1487,6 +1487,11 @@
         }
       }
     },
+    "array-differ": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg=="
+    },
     "array-filter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
@@ -1507,6 +1512,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+    },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
     },
     "asciify": {
       "version": "1.3.5",
@@ -2023,7 +2033,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -3852,7 +3862,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "shelljs": {
@@ -4516,7 +4526,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "requires": {
         "from2": "^2.1.1",
@@ -4974,7 +4984,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -4986,7 +4996,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5145,7 +5155,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -5157,7 +5167,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5561,6 +5571,18 @@
         }
       }
     },
+    "multimatch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+      "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+      "requires": {
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
+      }
+    },
     "murmurhash3js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
@@ -5849,7 +5871,7 @@
     },
     "opn": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "requires": {
         "object-assign": "^4.0.1"
@@ -5929,7 +5951,7 @@
     },
     "p-cancelable": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
       "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
     },
     "p-defer": {
@@ -6457,7 +6479,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -6853,7 +6875,7 @@
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
     },
     "snake-case": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2033,7 +2033,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -3862,7 +3862,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "shelljs": {
@@ -4526,7 +4526,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "requires": {
         "from2": "^2.1.1",
@@ -4984,7 +4984,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -4996,7 +4996,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5155,7 +5155,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -5167,7 +5167,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5871,7 +5871,7 @@
     },
     "opn": {
       "version": "3.0.3",
-      "resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "requires": {
         "object-assign": "^4.0.1"
@@ -5951,7 +5951,7 @@
     },
     "p-cancelable": {
       "version": "0.4.1",
-      "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
       "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
     },
     "p-defer": {
@@ -6479,7 +6479,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -6875,7 +6875,7 @@
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
     },
     "snake-case": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "lru_map": "^0.3.3",
     "metrics": "^0.1.21",
     "minimatch": "^3.0.4",
+    "multimatch": "^4.0.0",
     "murmurhash3js": "^3.0.1",
     "node-cache": "^4.2.0",
     "node-statsd": "^0.1.1",

--- a/test/project/local/NodeFsLocalProject.test.ts
+++ b/test/project/local/NodeFsLocalProject.test.ts
@@ -15,7 +15,6 @@ import {
 import { LocalProject } from "../../../lib/project/local/LocalProject";
 import { NodeFsLocalProject } from "../../../lib/project/local/NodeFsLocalProject";
 import { InMemoryProject } from "../../../lib/project/mem/InMemoryProject";
-import { Project } from "../../../lib/project/Project";
 import { toPromise } from "../../../lib/project/util/projectUtils";
 import { tempProject } from "../utils";
 

--- a/test/project/mem/InMemoryProject.test.ts
+++ b/test/project/mem/InMemoryProject.test.ts
@@ -8,6 +8,7 @@ import { InMemoryProject } from "../../../lib/project/mem/InMemoryProject";
 import { toPromise } from "../../../lib/project/util/projectUtils";
 
 import * as minimatch from "minimatch";
+import multimatch = require("multimatch");
 
 describe("InMemoryProject", () => {
 
@@ -66,6 +67,8 @@ describe("InMemoryProject", () => {
             const allFiles = await p.getFiles(".github/workflows/*.y{,a}ml");
             // Why does this work?
             assert(minimatch.match([".github/workflows/yours.yaml"], ".github/workflows/*.y{,a}ml"));
+            assert(multimatch([".github/workflows/yours.yaml"], ".github/workflows/*.y{,a}ml"));
+
             assert.deepStrictEqual(allFiles.map(f => f.path), [
                 ".github/workflows/mine.yml",
                 ".github/workflows/yours.yaml"]);

--- a/test/project/mem/InMemoryProject.test.ts
+++ b/test/project/mem/InMemoryProject.test.ts
@@ -9,6 +9,51 @@ import { toPromise } from "../../../lib/project/util/projectUtils";
 
 describe("InMemoryProject", () => {
 
+    describe("getFiles", () => {
+
+        it("all", async () => {
+            const p = InMemoryProject.of({
+                path: "evil.js",
+                content: "const awsLeak = 'AKIAIMW6ASF43DFX57X9'",
+            });
+            const allFiles = await p.getFiles();
+            assert.deepStrictEqual(allFiles.map(f => f.path), ["evil.js"]);
+        });
+
+        it("one", async () => {
+            const p = InMemoryProject.of({
+                path: "evil.js",
+                content: "const a = b;",
+            });
+            const allFiles = await p.getFiles("evil.js");
+            assert.deepStrictEqual(allFiles.map(f => f.path), ["evil.js"]);
+        });
+
+        it("none", async () => {
+            const p = InMemoryProject.of({
+                path: "evil.js",
+                content: "const a = b;",
+            });
+            const allFiles = await p.getFiles("xevil.js");
+            assert.deepStrictEqual(allFiles.map(f => f.path), []);
+        });
+
+        it("complex glob", async () => {
+            const p = InMemoryProject.of({
+                path: ".github/workflows/mine.yml",
+                content: "x",
+            }, {
+                path: ".github/workflows/yours.yaml",
+                content: "x",
+            });
+            const allFiles = await p.getFiles(".github/workflows/*.y{,a}ml");
+            assert.deepStrictEqual(allFiles.map(f => f.path), [
+                ".github/workflows/mine.yml",
+                ".github/workflows/yours.yaml"]);
+        });
+
+    });
+
     describe("binaryness", () => {
 
         it("inline file should be nonbinary by default", async () => {

--- a/test/project/mem/InMemoryProject.test.ts
+++ b/test/project/mem/InMemoryProject.test.ts
@@ -74,6 +74,26 @@ describe("InMemoryProject", () => {
                 ".github/workflows/yours.yaml"]);
         });
 
+        it("nested dot glob", async () => {
+            const p = InMemoryProject.of({
+                path: "test/.buckconfig",
+                content: "x",
+            });
+            const allFiles = await p.getFiles("**/.buckconfig");
+            assert.deepStrictEqual(allFiles.map(f => f.path), [
+                "test/.buckconfig"]);
+        });
+
+        it("nested dot glob x2", async () => {
+            const p = InMemoryProject.of({
+                path: "anywhere/.openshift/stuff",
+                content: "x",
+            });
+            const allFiles = await p.getFiles("**/.openshift/*");
+            assert.deepStrictEqual(allFiles.map(f => f.path), [
+                "anywhere/.openshift/stuff"]);
+        });
+
         it("respects negative globs", async () => {
             const p = InMemoryProject.of(
                 { path: "config/thing.js", content: "{ node: true }" },
@@ -337,7 +357,7 @@ describe("InMemoryProject", () => {
                     },
                 ).on("end", () => {
                 // Exclude node modules but not git as it's not at the root
-                assert.equal(count, 3);
+                assert.equal(count, 4);
                 done();
             });
         });

--- a/test/project/perf/diskPerformance.test.ts
+++ b/test/project/perf/diskPerformance.test.ts
@@ -1,0 +1,86 @@
+import { GitCommandGitProject } from "../../../lib/project/git/GitCommandGitProject";
+import { GitHubRepoRef } from "../../../lib/operations/common/GitHubRepoRef";
+import { Project } from "../../../lib/project/Project";
+import { gatherFromFiles } from "../../../lib/project/util/projectUtils";
+import { microgrammar } from "@atomist/microgrammar";
+import { findMatches } from "../../../lib/tree/ast/astUtils";
+import { MicrogrammarBasedFileParser } from "../../../lib/tree/ast/microgrammar/MicrogrammarBasedFileParser";
+
+let project: Project;
+
+async function getProject(): Promise<Project> {
+    if (project) {
+        return project;
+    }
+    project = await GitCommandGitProject.cloned(undefined, new GitHubRepoRef(
+        "spring-projects", "spring-boot"));
+    return project;
+}
+
+/**
+ * Pre optimization, with 6000 files, 42K imports
+ * file countx5: 5562ms
+ * look for one filex5: 1ms
+ * look for globx5: 5491ms
+ * read from globx5: 7552ms
+ * parse globx5: 21510ms
+ */
+describe("disk read performance", () => {
+
+    it("should count files", async () => {
+        const p = await getProject();
+        await time("file count", async () => {
+            const count = await p.totalFileCount();
+        }, 5);
+    }).timeout(200000);
+
+    it("should look for file", async () => {
+        const p = await getProject();
+        await time("look for one file", async () => {
+            const yes = await p.hasFile("pom.xml");
+        }, 5);
+    }).timeout(200000);
+
+    it("should look for glob", async () => {
+        const p = await getProject();
+        await time("look for glob", async () => {
+            await gatherFromFiles(p, "**/*.java", async f => true);
+        }, 5);
+    }).timeout(200000);
+
+    it("should read glob", async () => {
+        const p = await getProject();
+        await time("read from glob", async () => {
+            await gatherFromFiles(p, "**/*.java", async f => {
+                return f.getContent();
+            });
+        }, 5);
+    }).timeout(200000);
+
+    it("should parse glob", async () => {
+        const mg = microgrammar({
+            _import: "import",
+            fqn: /[a-z0-9A-Z\.]+/,
+        });
+        const p = await getProject();
+        await time("parse glob", async () => {
+            const matches = await findMatches(p, new MicrogrammarBasedFileParser("x", "x", mg),
+                "**/*.java", "//fqn");
+            // console.log("count=" + matches.length);
+        }, 5);
+    }).timeout(200000);
+
+});
+
+async function time(name: string,
+                    what: () => Promise<any>,
+                    n: number = 1): Promise<number> {
+    const st = new Date().getTime();
+    for (let i = 0; i < n; i++) {
+        await what();
+    }
+    const et = new Date().getTime();
+    const millis = et - st;
+    console.log(`${name}x${n}: ${millis}ms`);
+    return millis;
+}

--- a/test/project/perf/diskPerformance.test.ts
+++ b/test/project/perf/diskPerformance.test.ts
@@ -1,8 +1,8 @@
-import { GitCommandGitProject } from "../../../lib/project/git/GitCommandGitProject";
+import { microgrammar } from "@atomist/microgrammar";
 import { GitHubRepoRef } from "../../../lib/operations/common/GitHubRepoRef";
+import { GitCommandGitProject } from "../../../lib/project/git/GitCommandGitProject";
 import { Project } from "../../../lib/project/Project";
 import { gatherFromFiles } from "../../../lib/project/util/projectUtils";
-import { microgrammar } from "@atomist/microgrammar";
 import { findMatches } from "../../../lib/tree/ast/astUtils";
 import { MicrogrammarBasedFileParser } from "../../../lib/tree/ast/microgrammar/MicrogrammarBasedFileParser";
 

--- a/test/project/perf/diskPerformance.test.ts
+++ b/test/project/perf/diskPerformance.test.ts
@@ -25,7 +25,7 @@ async function getProject(): Promise<Project> {
  * read from globx5: 7552ms
  * parse globx5: 21510ms
  */
-describe("disk read performance", () => {
+describe.skip("disk read performance", () => {
 
     it("should count files", async () => {
         const p = await getProject();

--- a/test/project/util/parseUtils.test.ts
+++ b/test/project/util/parseUtils.test.ts
@@ -185,7 +185,7 @@ describe("parseUtils", () => {
             .then(_ => {
                 // Check file persistence
                 const updatedFile = t.findFileSync(f.path);
-                assert(updatedFile.getContentSync() === initialContent.replace(oldPackage, oldPackage + "x"),
+                assert.strictEqual(updatedFile.getContentSync(), initialContent.replace(oldPackage, oldPackage + "x"),
                     `Content is [${updatedFile.getContentSync()}]`);
                 done();
             }).catch(done);

--- a/test/project/util/projectUtils.test.ts
+++ b/test/project/util/projectUtils.test.ts
@@ -276,4 +276,16 @@ describe("projectUtils", () => {
             .then(done, done);
     });
 
+    it("gathers correct count", async () => {
+        const p = tempProject();
+        p.addFileSync("Thing", "A");
+        p.addFileSync("config/Thing", "B");
+        p.addFileSync("pom.xml", "A");
+        p.addFileSync("config/pom.xml", "B");
+        const files = await gatherFromFiles(p,
+            "**/pom.xml",
+            async file => file);
+        assert.strictEqual(files.length, 2);
+    });
+
 });

--- a/test/tree/ast/typescript/TypeScriptFileParser.test.ts
+++ b/test/tree/ast/typescript/TypeScriptFileParser.test.ts
@@ -175,7 +175,6 @@ describe("TypeScriptFileParser", () => {
         // console.log(stringify(root, null, 2));
         assert(functions.length === 1);
         assert.equal(functions[0].identifier, "it");
-        console.log(JSON.stringify(functions[0]));
         assert.equal(functions[0].canonicalBody,
             "function it(a, b){return 'frogs';}");
         assert.equal(functions[0].path,

--- a/test/tree/ast/typescript/javaScriptFileParserProject.test.ts
+++ b/test/tree/ast/typescript/javaScriptFileParserProject.test.ts
@@ -25,7 +25,7 @@ describe("TypeScriptFileParser real project parsing: JavaScript", () => {
                 assert(matchResults.map(m => m.$value).includes(TypeScriptFileParser.name));
                 done();
             }).catch(done);
-    }).timeout(5000);
+    }).timeout(15000);
 
     it("should parse sources from project and use a path expression to find values using convenience method", done => {
         findValues(thisProject, TypeScriptES6FileParser,
@@ -35,7 +35,7 @@ describe("TypeScriptFileParser real project parsing: JavaScript", () => {
                 assert(values.includes(TypeScriptFileParser.name));
                 done();
             }).catch(done);
-    }).timeout(5000);
+    }).timeout(15000);
 
     it("should parse sources from project and find functions", done => {
         findValues(thisProject, TypeScriptES6FileParser,
@@ -45,6 +45,6 @@ describe("TypeScriptFileParser real project parsing: JavaScript", () => {
                 assert(values.length > 2);
                 done();
             }).catch(done);
-    }).timeout(5000);
+    }).timeout(15000);
 
 });

--- a/test/tree/ast/typescript/typeScriptFileParserProject.test.ts
+++ b/test/tree/ast/typescript/typeScriptFileParserProject.test.ts
@@ -26,7 +26,7 @@ describe("TypeScriptFileParser real project parsing: TypeScript", () => {
                     ["TypeScriptFileParser", "TypeScriptAstNodeTreeNode"]);
                 done();
             }).catch(done);
-    }).timeout(5000);
+    }).timeout(15000);
 
     it("should parse sources from project and use a path expression to find values using convenience method", done => {
         findValues(thisProject, TypeScriptES6FileParser,
@@ -37,7 +37,7 @@ describe("TypeScriptFileParser real project parsing: TypeScript", () => {
                     ["TypeScriptFileParser", "TypeScriptAstNodeTreeNode"]);
                 done();
             }).catch(done);
-    }).timeout(5000);
+    }).timeout(15000);
 
     it("should parse sources from project and find functions", done => {
         findValues(thisProject, TypeScriptES6FileParser,
@@ -47,7 +47,7 @@ describe("TypeScriptFileParser real project parsing: TypeScript", () => {
                 assert(values.length > 2);
                 done();
             }).catch(done);
-    }).timeout(5000);
+    }).timeout(15000);
 
     it("should parse sources from project and find exported functions", done => {
         findMatches(thisProject, TypeScriptES6FileParser,
@@ -57,7 +57,7 @@ describe("TypeScriptFileParser real project parsing: TypeScript", () => {
                 assert(values.length > 2);
                 done();
             }).catch(done);
-    }).timeout(5000);
+    }).timeout(15000);
 
     it("should find all exported functions in project", done => {
         findValues(thisProject, TypeScriptES6FileParser,
@@ -67,6 +67,6 @@ describe("TypeScriptFileParser real project parsing: TypeScript", () => {
                 assert(values.length > 5);
                 done();
             }).catch(done);
-    }).timeout(5000);
+    }).timeout(15000);
 
 });


### PR DESCRIPTION
Makes project operations significantly faster.

- Caches file paths in `Project` to make successive glob and file searches much faster. This is available via the new `getFiles` method.
- Make `projectUtils` use the new method.
- Introduces user `cache` property in `Project` and `File` allowing expensive computations to be stored in a `Project` instance during its lifetime.
- Change `astUtils` to cache the AST for each parser by default.
- Add disk performance benchmark tests, skipped by default.

Also deprecates some `astUtils` functions, adding new functions that take an options object rather than individual parameters.

*Needs further testing before merging* (@lievendoclo), as well as review.

*DO NOT MERGE until further investigation. There may be a bug shown in aspect-sdm*