### PR TITLE
Use host configuration in Express listen call

### DIFF
--- a/lib/internal/transport/express/ExpressServer.ts
+++ b/lib/internal/transport/express/ExpressServer.ts
@@ -160,10 +160,11 @@ export class ExpressServer {
         return portPromise
             .then(port => {
                 this.configuration.http.port = port;
-                this.exp.listen(port, () => {
+                const hostname = this.configuration.http.host || "127.0.0.1";
+                this.exp.listen(port, hostname, () => {
                     logger.debug(
                         `Atomist automation client api running at 'http://${
-                            this.configuration.http.host}:${port}'`);
+                            hostname}:${port}'`);
                     return true;
                 }).on("error", err => {
                     logger.error(`Failed to start automation client api: ${err.message}`);

--- a/lib/internal/transport/express/ExpressServer.ts
+++ b/lib/internal/transport/express/ExpressServer.ts
@@ -163,8 +163,7 @@ export class ExpressServer {
                 const hostname = this.configuration.http.host || "127.0.0.1";
                 this.exp.listen(port, hostname, () => {
                     logger.debug(
-                        `Atomist automation client api running at 'http://${
-                            hostname}:${port}'`);
+                        `Atomist automation client api running at 'http://${hostname}:${port}'`);
                     return true;
                 }).on("error", err => {
                     logger.error(`Failed to start automation client api: ${err.message}`);


### PR DESCRIPTION
Within Windows WSL, I need to set this to 0.0.0.0 in order to see the port from the browser (in Windows,
when the SDM is running in the linux subsystem)