### PR TITLE
Add Apollo client identification headers to ApolloGraphClient

### DIFF
--- a/lib/graph/ApolloGraphClientFactory.ts
+++ b/lib/graph/ApolloGraphClientFactory.ts
@@ -24,8 +24,13 @@ export class ApolloGraphClientFactory implements GraphClientFactory {
         if (graphClient) {
             return graphClient;
         } else {
+            const headers = {
+                Authorization: `Bearer ${configuration.apiKey}`,
+                "apollographql-client-name": `${configuration.name}/${workspaceId}`,
+                "apollographql-client-version": configuration.version,
+            };
             graphClient = new ApolloGraphClient(`${configuration.endpoints.graphql}/${workspaceId}`,
-                { Authorization: `Bearer ${configuration.apiKey}` }, this.configure(configuration));
+                headers, this.configure(configuration));
             this.graphClients.set<GraphClient>(workspaceId, graphClient);
             return graphClient;
         }

--- a/lib/graph/ApolloGraphClientFactory.ts
+++ b/lib/graph/ApolloGraphClientFactory.ts
@@ -25,7 +25,7 @@ export class ApolloGraphClientFactory implements GraphClientFactory {
             return graphClient;
         } else {
             const headers = {
-                Authorization: `Bearer ${configuration.apiKey}`,
+                "Authorization": `Bearer ${configuration.apiKey}`,
                 "apollographql-client-name": `${configuration.name}/${workspaceId}`,
                 "apollographql-client-version": configuration.version,
             };


### PR DESCRIPTION
The aim of this is to get a name header of `registration/workspace-id` and the version of the automation as the version header.